### PR TITLE
Remove declarations of inlined function Rf_allocVector as they create…

### DIFF
--- a/src/include/CXXR/VectorBase.h
+++ b/src/include/CXXR/VectorBase.h
@@ -426,7 +426,7 @@ extern "C" {
      *
      * @return Pointer to the created vector.
      */
-    SEXP Rf_allocVector(SEXPTYPE stype, R_xlen_t length);
+    /*SEXP Rf_allocVector(SEXPTYPE stype, R_xlen_t length);*/
 
     /** @brief Is an RObject a vector?
      *

--- a/src/include/Rinternals.h
+++ b/src/include/Rinternals.h
@@ -463,7 +463,6 @@ SEXP Rf_allocMatrix(SEXPTYPE, int, int);
 SEXP Rf_allocList(unsigned int);
 SEXP Rf_allocS4Object(void);
 SEXP Rf_allocSExp(SEXPTYPE);
-SEXP Rf_allocVector(SEXPTYPE, R_xlen_t);
 SEXP Rf_allocVector3(SEXPTYPE, R_xlen_t, void*);
 R_xlen_t Rf_any_duplicated(SEXP x, Rboolean from_last);
 R_xlen_t Rf_any_duplicated3(SEXP x, SEXP incomp, Rboolean from_last);


### PR DESCRIPTION
… multiple symbol defs. inline.o should contain the only one visible.

Not sure if this issue affects other compilers, but this fixes compiling with gcc 4.9.2 on ubuntu.