### PR TITLE
Support and test more compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ addons:
         - liblzma-dev
         - libpcre3-dev
         - libedit-dev
-
 env:
   global:
     # By default, rho uses its own implementation of tar written in R.
@@ -31,6 +30,13 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+            - gfortran
+            - libboost-all-dev
+            - zlib1g-dev
+            - libbz2-dev
+            - liblzma-dev
+            - libpcre3-dev
+            - libedit-dev
             - gcc-4.9
             - g++-4.9
       env: CC=gcc-4.9 CXX=g++-4.9
@@ -40,6 +46,13 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+            - gfortran
+            - libboost-all-dev
+            - zlib1g-dev
+            - libbz2-dev
+            - liblzma-dev
+            - libpcre3-dev
+            - libedit-dev
             - gcc-5.0
             - g++-5.0
       env: CC=gcc-5.0 CXX=g++-5.0
@@ -49,6 +62,13 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+            - gfortran
+            - libboost-all-dev
+            - zlib1g-dev
+            - libbz2-dev
+            - liblzma-dev
+            - libpcre3-dev
+            - libedit-dev
             - clang-3.4
             - llvm-3.4-dev
       env: CC=clang-3.4 CXX=clang++-3.4 LLVM_CONFIG=/usr/bin/llvm-config-3.4
@@ -58,6 +78,13 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+            - gfortran
+            - libboost-all-dev
+            - zlib1g-dev
+            - libbz2-dev
+            - liblzma-dev
+            - libpcre3-dev
+            - libedit-dev
             - clang-3.5
             - llvm-3.5-dev
       env: CC=clang-3.5 CXX=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5
@@ -75,7 +102,15 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - debian-sid
           packages:
+            - gfortran
+            - libboost-all-dev
+            - zlib1g-dev
+            - libbz2-dev
+            - liblzma-dev
+            - libpcre3-dev
+            - libedit-dev
             - clang-3.7
             - llvm-3.7-dev
       env: CC=clang-3.7 CXX=clang++-3.7 LLVM_CONFIG=/usr/bin/llvm-config-3.7
@@ -84,7 +119,15 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - debian-sid
           packages:
+            - gfortran
+            - libboost-all-dev
+            - zlib1g-dev
+            - libbz2-dev
+            - liblzma-dev
+            - libpcre3-dev
+            - libedit-dev
             - clang-3.8
             - llvm-3.8-dev
       env: CC=clang-3.8 CXX=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8
@@ -95,6 +138,13 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+            - gfortran
+            - libboost-all-dev
+            - zlib1g-dev
+            - libbz2-dev
+            - liblzma-dev
+            - libpcre3-dev
+            - libedit-dev
             - clang-3.5
             - llvm-3.5-dev
       env: CC=clang-3.5 CXX=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5 ASAN_OPTIONS="detect_leaks=0" CFLAGS="-g -O1 -fsanitize=address" CXXFLAGS="${CFLAGS}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: cpp
 before_install:
   - sudo apt-get -y remove clang
-  - sudo apt-get install clang-3.4
+  - sudo apt-get -y install clang-3.4
 env:
   global:
     # By default, rho uses its own implementation of tar written in R.

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ matrix:
             - libedit-dev
             - clang-3.8
             - llvm-3.8-dev
-      env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8 ASAN_OPTIONS="detect_leaks=0" CFLAGS="-g -O1 -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls" CXXFLAGS="${CFLAGS}" MAIN_LDFLAGS="${CFLAGS}"
+      env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8 ASAN_OPTIONS="detect_leaks=0 allow_user_segv_handler=true" CFLAGS="-g -O1 -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls" CXXFLAGS="${CFLAGS}" MAIN_LDFLAGS="${CFLAGS}"
 
     # With undefined behaviour sanitizer enabled.  Use the most recent
     # supported verison of clang, to get the best error detection.

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ matrix:
             - libedit-dev
             - clang-3.8
             - llvm-3.8-dev
-      env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8 ASAN_OPTIONS="detect_leaks=0 allow_user_segv_handler=true" CFLAGS="-g -O1 -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls" CXXFLAGS="${CFLAGS}" MAIN_LDFLAGS="${CFLAGS}"
+      env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8 ASAN_OPTIONS="detect_leaks=0 allow_user_segv_handler=true" CFLAGS="-g -O2 -fsanitize=address" CXXFLAGS="${CFLAGS}" MAIN_LDFLAGS="${CFLAGS}"
 
     # With undefined behaviour sanitizer enabled.  Use the most recent
     # supported verison of clang, to get the best error detection.
@@ -103,7 +103,7 @@ matrix:
             - libedit-dev
             - clang-3.8
             - llvm-3.8-dev
-      env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8 UBSAN_OPTIONS="print_stacktrace=1" CFLAGS="-g -O1 -fsanitize=undefined -fno-omit-frame-pointer -fno-optimize-sibling-calls" CXXFLAGS="${CFLAGS}" MAIN_LDFLAGS="${CFLAGS}"
+      env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8 UBSAN_OPTIONS="print_stacktrace=1 suppressions=`pwd`/.ubsan_suppressions" CFLAGS="-g -O2 -fsanitize=undefined" CXXFLAGS="${CFLAGS}" MAIN_LDFLAGS="${CFLAGS}"
 
     - compiler: clang
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,12 @@
 sudo: required
 dist: trusty
 language: cpp
-compiler:
-        - clang
-        - gcc
-env:
-  global:
-    # By default, rho uses its own implementation of tar written in R.
-    # It's really slow, so use system tar instead.
-    - TAR=/bin/tar
-    - R_BUILD_TAR=/bin/tar
-    - R_INSTALL_TAR=/bin/tar
-matrix:
-  allow_failures:
-    - compiler: gcc
-install:
-        - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
+
 addons:
   apt:
         sources:
         - ubuntu-toolchain-r-test
         packages:
-        - llvm-3.5-dev
-        - gcc-4.9
-        - g++-4.9
         - gfortran
         - libboost-all-dev
         - zlib1g-dev
@@ -32,10 +15,95 @@ addons:
         - libpcre3-dev
         - libedit-dev
 
+env:
+  global:
+    # By default, rho uses its own implementation of tar written in R.
+    # It's really slow, so use system tar instead.
+    - TAR=/bin/tar
+    - R_BUILD_TAR=/bin/tar
+    - R_INSTALL_TAR=/bin/tar
+
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.9
+            - g++-4.9
+      env: CC=gcc-4.9 CXX=g++-4.9
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5.0
+            - g++-5.0
+      env: CC=gcc-5.0 CXX=g++-5.0
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-3.4
+            - llvm-3.4-dev
+      env: CC=clang-3.4 CXX=clang++-3.4 LLVM_CONFIG=/usr/bin/llvm-config-3.4
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-3.5
+            - llvm-3.5-dev
+      env: CC=clang-3.5 CXX=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-3.6
+            - llvm-3.6-dev
+      env: CC=clang-3.6 CXX=clang++-3.6 LLVM_CONFIG=/usr/bin/llvm-config-3.6
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-3.7
+            - llvm-3.7-dev
+      env: CC=clang-3.7 CXX=clang++-3.7 LLVM_CONFIG=/usr/bin/llvm-config-3.7
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-3.8
+            - llvm-3.8-dev
+      env: CC=clang-3.8 CXX=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8
+    # With address sanitizer enabled.
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-3.5
+            - llvm-3.5-dev
+      env: CC=clang-3.5 CXX=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5 ASAN_OPTIONS="detect_leaks=0" CFLAGS="-g -O1 -fsanitize=address" CXXFLAGS="${CFLAGS}"
+
 script:
         - tools/rsync-recommended
         - ./configure
           --enable-llvm-jit=yes
-          --with-llvm=/usr/bin/llvm-config-3.5
+          --with-llvm=$LLVM_CONFIG
         - travis_wait 60 make -j 2
+        # TODO: upgrade to check-devel.
         - travis_wait 60 make -j 2 check

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: cpp
 before_install:
-  - apt-get remove clang-3.5
+  - sudo apt-get remove clang-3.5
 env:
   global:
     # By default, rho uses its own implementation of tar written in R.
@@ -29,6 +29,7 @@ matrix:
             - gcc-4.9
             - g++-4.9
       env: C_COMPILER=gcc-4.9 CXX_COMPILER=g++-4.9
+
     - compiler: gcc
       addons:
         apt:
@@ -45,6 +46,7 @@ matrix:
             - gcc-5
             - g++-5
       env: C_COMPILER=gcc-5 CXX_COMPILER=g++-5
+
     - compiler: clang
       addons:
         apt:
@@ -61,72 +63,6 @@ matrix:
             - clang-3.4
             - llvm-3.4-dev
       env: C_COMPILER=clang CXX_COMPILER=clang++ LLVM_CONFIG=/usr/bin/llvm-config-3.4
-    - compiler: clang
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gfortran
-            - libboost-all-dev
-            - zlib1g-dev
-            - libbz2-dev
-            - liblzma-dev
-            - libpcre3-dev
-            - libedit-dev
-            - clang-3.5
-            - llvm-3.5-dev
-      env: C_COMPILER=clang-3.5 CXX_COMPILER=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5
-    - compiler: clang
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gfortran
-            - libboost-all-dev
-            - zlib1g-dev
-            - libbz2-dev
-            - liblzma-dev
-            - libpcre3-dev
-            - libedit-dev
-            - clang-3.6
-            - llvm-3.6-dev
-      env: C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6 LLVM_CONFIG=/usr/bin/llvm-config-3.6
-    - compiler: clang
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - debian-sid
-          packages:
-            - gfortran
-            - libboost-all-dev
-            - zlib1g-dev
-            - libbz2-dev
-            - liblzma-dev
-            - libpcre3-dev
-            - libedit-dev
-            - clang-3.7
-            - llvm-3.7-dev
-      env: C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7 LLVM_CONFIG=/usr/bin/llvm-config-3.7
-    - compiler: clang
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - debian-sid
-          packages:
-            - gfortran
-            - libboost-all-dev
-            - zlib1g-dev
-            - libbz2-dev
-            - liblzma-dev
-            - libpcre3-dev
-            - libedit-dev
-            - clang-3.8
-            - llvm-3.8-dev
-      env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8
     # With address sanitizer enabled.
     - compiler: clang
       addons:
@@ -144,6 +80,76 @@ matrix:
             - clang-3.5
             - llvm-3.5-dev
       env: C_COMPILER=clang-3.5 CXX_COMPILER=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5 ASAN_OPTIONS="detect_leaks=0" CFLAGS="-g -O1 -fsanitize=address" CXXFLAGS="${CFLAGS}" LDFLAGS="${CFLAGS}"
+
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gfortran
+            - libboost-all-dev
+            - zlib1g-dev
+            - libbz2-dev
+            - liblzma-dev
+            - libpcre3-dev
+            - libedit-dev
+            - clang-3.5
+            - llvm-3.5-dev
+      env: C_COMPILER=clang-3.5 CXX_COMPILER=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5
+
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gfortran
+            - libboost-all-dev
+            - zlib1g-dev
+            - libbz2-dev
+            - liblzma-dev
+            - libpcre3-dev
+            - libedit-dev
+            - clang-3.6
+            - llvm-3.6-dev
+      env: C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6 LLVM_CONFIG=/usr/bin/llvm-config-3.6
+
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - debian-sid
+          packages:
+            - gfortran
+            - libboost-all-dev
+            - zlib1g-dev
+            - libbz2-dev
+            - liblzma-dev
+            - libpcre3-dev
+            - libedit-dev
+            - clang-3.7
+            - llvm-3.7-dev
+      env: C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7 LLVM_CONFIG=/usr/bin/llvm-config-3.7
+
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - debian-sid
+          packages:
+            - gfortran
+            - libboost-all-dev
+            - zlib1g-dev
+            - libbz2-dev
+            - liblzma-dev
+            - libpcre3-dev
+            - libedit-dev
+            - clang-3.8
+            - llvm-3.8-dev
+      env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8
 
 script:
         - tools/rsync-recommended

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: required
 dist: trusty
 language: cpp
-before_install:
-  - sudo apt-get -y remove clang
-  - sudo apt-get -y install clang-3.4
 env:
   global:
     # By default, rho uses its own implementation of tar written in R.
@@ -48,22 +45,23 @@ matrix:
             - g++-5
       env: C_COMPILER=gcc-5 CXX_COMPILER=g++-5
 
-    - compiler: clang
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gfortran
-            - libboost-all-dev
-            - zlib1g-dev
-            - libbz2-dev
-            - liblzma-dev
-            - libpcre3-dev
-            - libedit-dev
-            - clang-3.4
-            - llvm-3.4-dev
-      env: C_COMPILER=clang CXX_COMPILER=clang++ LLVM_CONFIG=/usr/bin/llvm-config-3.4
+    # - compiler: clang
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #       packages:
+    #         - gfortran
+    #         - libboost-all-dev
+    #         - zlib1g-dev
+    #         - libbz2-dev
+    #         - liblzma-dev
+    #         - libpcre3-dev
+    #         - libedit-dev
+    #         - clang-3.4
+    #         - llvm-3.4-dev
+    #   env: C_COMPILER=clang CXX_COMPILER=clang++ LLVM_CONFIG=/usr/bin/llvm-config-3.4
+
     # With address sanitizer enabled.
     - compiler: clang
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
             - libedit-dev
             - gcc-4.9
             - g++-4.9
-      env: CC=gcc-4.9 CXX=g++-4.9
+      env: C_COMPILER=gcc-4.9 CXX_COMPILER=g++-4.9
     - compiler: gcc
       addons:
         apt:
@@ -55,7 +55,7 @@ matrix:
             - libedit-dev
             - gcc-5.0
             - g++-5.0
-      env: CC=gcc-5.0 CXX=g++-5.0
+      env: C_COMPILER=gcc-5.0 CXX_COMPILER=g++-5.0
     - compiler: clang
       addons:
         apt:
@@ -71,7 +71,7 @@ matrix:
             - libedit-dev
             - clang-3.4
             - llvm-3.4-dev
-      env: CC=clang-3.4 CXX=clang++-3.4 LLVM_CONFIG=/usr/bin/llvm-config-3.4
+      env: C_COMPILER=clang-3.4 CXX_COMPILER=clang++-3.4 LLVM_CONFIG=/usr/bin/llvm-config-3.4
     - compiler: clang
       addons:
         apt:
@@ -87,16 +87,23 @@ matrix:
             - libedit-dev
             - clang-3.5
             - llvm-3.5-dev
-      env: CC=clang-3.5 CXX=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5
+      env: C_COMPILER=clang-3.5 CXX_COMPILER=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5
     - compiler: clang
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+            - gfortran
+            - libboost-all-dev
+            - zlib1g-dev
+            - libbz2-dev
+            - liblzma-dev
+            - libpcre3-dev
+            - libedit-dev
             - clang-3.6
             - llvm-3.6-dev
-      env: CC=clang-3.6 CXX=clang++-3.6 LLVM_CONFIG=/usr/bin/llvm-config-3.6
+      env: C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6 LLVM_CONFIG=/usr/bin/llvm-config-3.6
     - compiler: clang
       addons:
         apt:
@@ -113,7 +120,7 @@ matrix:
             - libedit-dev
             - clang-3.7
             - llvm-3.7-dev
-      env: CC=clang-3.7 CXX=clang++-3.7 LLVM_CONFIG=/usr/bin/llvm-config-3.7
+      env: C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7 LLVM_CONFIG=/usr/bin/llvm-config-3.7
     - compiler: clang
       addons:
         apt:
@@ -130,7 +137,7 @@ matrix:
             - libedit-dev
             - clang-3.8
             - llvm-3.8-dev
-      env: CC=clang-3.8 CXX=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8
+      env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8
     # With address sanitizer enabled.
     - compiler: clang
       addons:
@@ -147,11 +154,11 @@ matrix:
             - libedit-dev
             - clang-3.5
             - llvm-3.5-dev
-      env: CC=clang-3.5 CXX=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5 ASAN_OPTIONS="detect_leaks=0" CFLAGS="-g -O1 -fsanitize=address" CXXFLAGS="${CFLAGS}"
+      env: C_COMPILER=clang-3.5 CXX_COMPILER=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5 ASAN_OPTIONS="detect_leaks=0" CFLAGS="-g -O1 -fsanitize=address" CXX_COMPILERFLAGS="${CFLAGS}"
 
 script:
         - tools/rsync-recommended
-        - ./configure
+        - CC=${C_COMPILER} CXX=${CXX_COMPILER} ./configure
           --enable-llvm-jit=yes
           --with-llvm=$LLVM_CONFIG
         - travis_wait 60 make -j 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: required
 dist: trusty
 language: cpp
 before_install:
-  - sudo apt-get remove clang-3.5
+  - sudo apt-get -y remove clang
+  - sudo apt-get install clang-3.4
 env:
   global:
     # By default, rho uses its own implementation of tar written in R.

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ matrix:
             - libedit-dev
             - clang-3.5
             - llvm-3.5-dev
-      env: C_COMPILER=clang-3.5 CXX_COMPILER=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5 ASAN_OPTIONS="detect_leaks=0" CFLAGS="-g -O1 -fsanitize=address" CXXFLAGS="${CFLAGS}" LDFLAGS="${CFLAGS}"
+      env: C_COMPILER=clang-3.5 CXX_COMPILER=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5 ASAN_OPTIONS="detect_leaks=0" CFLAGS="-g -O1 -fsanitize=address" CXXFLAGS="${CFLAGS}" MAIN_LDFLAGS="${CFLAGS}"
 
     - compiler: clang
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,8 @@
 sudo: required
 dist: trusty
 language: cpp
-
-addons:
-  apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - gfortran
-        - libboost-all-dev
-        - zlib1g-dev
-        - libbz2-dev
-        - liblzma-dev
-        - libpcre3-dev
-        - libedit-dev
+before_install:
+  - apt-get remove clang-3.5
 env:
   global:
     # By default, rho uses its own implementation of tar written in R.
@@ -161,7 +150,7 @@ script:
         - ${CXX_COMPILER} --version
         - CC=${C_COMPILER} CXX=${CXX_COMPILER} ./configure
           --enable-llvm-jit=yes
-          --with-llvm=$LLVM_CONFIG
+          --with-llvm=$LLVM_CONFIG || cat config.log
         - travis_wait 60 make -j 2
         # TODO: upgrade to check-devel.
         - travis_wait 60 make -j 2 check

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,9 @@ matrix:
             - liblzma-dev
             - libpcre3-dev
             - libedit-dev
-            - gcc-5.0
-            - g++-5.0
-      env: C_COMPILER=gcc-5.0 CXX_COMPILER=g++-5.0
+            - gcc-5
+            - g++-5
+      env: C_COMPILER=gcc-5 CXX_COMPILER=g++-5
     - compiler: clang
       addons:
         apt:
@@ -71,7 +71,7 @@ matrix:
             - libedit-dev
             - clang-3.4
             - llvm-3.4-dev
-      env: C_COMPILER=clang-3.4 CXX_COMPILER=clang++-3.4 LLVM_CONFIG=/usr/bin/llvm-config-3.4
+      env: C_COMPILER=clang CXX_COMPILER=clang++ LLVM_CONFIG=/usr/bin/llvm-config-3.4
     - compiler: clang
       addons:
         apt:
@@ -154,10 +154,11 @@ matrix:
             - libedit-dev
             - clang-3.5
             - llvm-3.5-dev
-      env: C_COMPILER=clang-3.5 CXX_COMPILER=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5 ASAN_OPTIONS="detect_leaks=0" CFLAGS="-g -O1 -fsanitize=address" CXX_COMPILERFLAGS="${CFLAGS}"
+      env: C_COMPILER=clang-3.5 CXX_COMPILER=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5 ASAN_OPTIONS="detect_leaks=0" CFLAGS="-g -O1 -fsanitize=address" CXXFLAGS="${CFLAGS}" LDFLAGS="${CFLAGS}"
 
 script:
         - tools/rsync-recommended
+        - ${CXX_COMPILER} --version
         - CC=${C_COMPILER} CXX=${CXX_COMPILER} ./configure
           --enable-llvm-jit=yes
           --with-llvm=$LLVM_CONFIG

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - debian-sid
           packages:
             - gfortran
             - libboost-all-dev
@@ -91,6 +92,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - debian-sid
           packages:
             - gfortran
             - libboost-all-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -178,6 +178,8 @@ matrix:
   allow_failures:
     # Building with llvm 3.7 currently segfaults.  Needs investigating.
     - env: C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7 LLVM_CONFIG=/usr/bin/llvm-config-3.7  
+    # Likewise for the ubsan run.
+    - env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8 UBSAN_OPTIONS="print_stacktrace=1 suppressions=`pwd`/.ubsan_suppressions" CFLAGS="-g -O2 -fsanitize=undefined" CXXFLAGS="${CFLAGS}" MAIN_LDFLAGS="${CFLAGS}"
 
 script:
         - tools/rsync-recommended

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ matrix:
             - g++-5
       env: C_COMPILER=gcc-5 CXX_COMPILER=g++-5
 
+    # TODO: work out how to use clang 3.4 on travis.
     # - compiler: clang
     #   addons:
     #     apt:
@@ -62,7 +63,10 @@ matrix:
     #         - llvm-3.4-dev
     #   env: C_COMPILER=clang CXX_COMPILER=clang++ LLVM_CONFIG=/usr/bin/llvm-config-3.4
 
-    # With address sanitizer enabled.
+    # With address sanitizer enabled.  Use the most recent supported verison
+    # of clang, to get the best error detection.
+    # TODO: enable leak detection.
+    # TODO: enable initialization order checking.
     - compiler: clang
       addons:
         apt:
@@ -76,9 +80,28 @@ matrix:
             - liblzma-dev
             - libpcre3-dev
             - libedit-dev
-            - clang-3.5
-            - llvm-3.5-dev
-      env: C_COMPILER=clang-3.5 CXX_COMPILER=clang++-3.5 LLVM_CONFIG=/usr/bin/llvm-config-3.5 ASAN_OPTIONS="detect_leaks=0" CFLAGS="-g -O1 -fsanitize=address" CXXFLAGS="${CFLAGS}" MAIN_LDFLAGS="${CFLAGS}"
+            - clang-3.8
+            - llvm-3.8-dev
+      env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8 ASAN_OPTIONS="detect_leaks=0" CFLAGS="-g -O1 -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls" CXXFLAGS="${CFLAGS}" MAIN_LDFLAGS="${CFLAGS}"
+
+    # With undefined behaviour sanitizer enabled.  Use the most recent
+    # supported verison of clang, to get the best error detection.
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gfortran
+            - libboost-all-dev
+            - zlib1g-dev
+            - libbz2-dev
+            - liblzma-dev
+            - libpcre3-dev
+            - libedit-dev
+            - clang-3.8
+            - llvm-3.8-dev
+      env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8 UBSAN_OPTIONS="print_stacktrace=1" CFLAGS="-g -O1 -fsanitize=undefined -fno-omit-frame-pointer -fno-optimize-sibling-calls" CXXFLAGS="${CFLAGS}" MAIN_LDFLAGS="${CFLAGS}"
 
     - compiler: clang
       addons:
@@ -149,6 +172,10 @@ matrix:
             - clang-3.8
             - llvm-3.8-dev
       env: C_COMPILER=clang-3.8 CXX_COMPILER=clang++-3.8 LLVM_CONFIG=/usr/bin/llvm-config-3.8
+
+  allow_failures:
+    # Building with llvm 3.7 currently segfaults.  Needs investigating.
+    - env: C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7 LLVM_CONFIG=/usr/bin/llvm-config-3.7  
 
 script:
         - tools/rsync-recommended

--- a/.ubsan_suppressions
+++ b/.ubsan_suppressions
@@ -1,0 +1,1 @@
+vptr:ilist.h

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Compiling rho requires a GCC or Clang compiler with C++ 11 support and fortran s
    * libedit
 
 Compilation of the LLVM JIT requires clang 3.4 or later and the matching
-version of the LLVM library.  We haven't tested versions later than 3.6.
+version of the LLVM library (except building on clang 3.7 is currently broken).
 
 Rho has been tested to compile on both Linux and Mac OSX systems.
 
@@ -39,7 +39,7 @@ in order to find bugs more easily. (If using clang >= 3.6, either remove the `-f
 ## Notable Known Issues
 
 * Currently rho doesn't support packages that contain native code that uses the `USE_RINTERNALS` macro.  This includes Rcpp, rJava, data.table, xts and all the packages that depend on them.
-* Our testing on different platforms and compilers is currently very limited.  Building with clang 3.5 on ubuntu trusty should always work.  OSX, other linux distros and recent versions of clang and gcc are also supported, but aren't regularly tested.
+* Our testing on different platforms is currently very limited.  We currently test on Ubuntu trusty with gcc 4.9, gcc 5.0, clang-3.5, clang-3.6 and clang-3.8, so those should always work.  OSX and other linux distros are also supported, but aren't regularly tested.
 
 ## Rho Discussion Mailing List.
 

--- a/configure
+++ b/configure
@@ -38184,7 +38184,7 @@ fi
 
 
 ## LLVM
-want_llvm_jit = no
+want_llvm_jit=no
 if test "${enable_llvm_jit}" = yes; then
   if `${CC} --version | grep -q clang`; then
 
@@ -38306,7 +38306,7 @@ $as_echo "#define HAVE_LLVM /**/" >>confdefs.h
 
 $as_echo "#define ENABLE_LLVM_JIT 1" >>confdefs.h
 
-    want_llvm_jit = yes
+    want_llvm_jit=yes
   else
     { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: \"clang compiler needed for llvm-jit\"" >&5
 $as_echo "$as_me: WARNING: \"clang compiler needed for llvm-jit\"" >&2;}

--- a/configure
+++ b/configure
@@ -38184,7 +38184,9 @@ fi
 
 
 ## LLVM
+want_llvm_jit = no
 if test "${enable_llvm_jit}" = yes; then
+  if `${CC} --version | grep -q clang`; then
 
 
 # Check whether --with-llvm was given.
@@ -38304,9 +38306,14 @@ $as_echo "#define HAVE_LLVM /**/" >>confdefs.h
 
 $as_echo "#define ENABLE_LLVM_JIT 1" >>confdefs.h
 
+    want_llvm_jit = yes
+  else
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: \"clang compiler needed for llvm-jit\"" >&5
+$as_echo "$as_me: WARNING: \"clang compiler needed for llvm-jit\"" >&2;}
+  fi
 fi
 
- if test "${enable_llvm_jit}" = yes; then
+ if test "${want_llvm_jit}" = yes; then
   BUILD_LLVM_JIT_TRUE=
   BUILD_LLVM_JIT_FALSE='#'
 else
@@ -50390,6 +50397,15 @@ if test -z "${rho_options}"; then
   rho_options="Provenance Tracking"
 else
   rho_options="${rho_options}${separator}Provenance Tracking"
+fi
+fi
+if test "${enable_llvm_jit}" = yes; then
+  separator=", "
+test -z "${separator}" && separator=" "
+if test -z "${rho_options}"; then
+  rho_options="LLVM JIT compiler"
+else
+  rho_options="${rho_options}${separator}LLVM JIT compiler"
 fi
 fi
 

--- a/configure
+++ b/configure
@@ -50407,6 +50407,14 @@ if test -z "${rho_options}"; then
 else
   rho_options="${rho_options}${separator}LLVM JIT compiler"
 fi
+else
+  separator=", "
+test -z "${separator}" && separator=" "
+if test -z "${r_no_options}"; then
+  r_no_options="LLVM JIT compiler"
+else
+  r_no_options="${r_no_options}${separator}LLVM JIT compiler"
+fi
 fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: result:

--- a/configure
+++ b/configure
@@ -50399,7 +50399,7 @@ else
   rho_options="${rho_options}${separator}Provenance Tracking"
 fi
 fi
-if test "${enable_llvm_jit}" = yes; then
+if test "${want_llvm_jit}" = yes; then
   separator=", "
 test -z "${separator}" && separator=" "
 if test -z "${rho_options}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -2371,12 +2371,18 @@ R_SYS_POSIX_LEAPSECONDS
 gl_STAT_TIME
 
 ## LLVM
+want_llvm_jit = no
 if test "${enable_llvm_jit}" = yes; then
-   AX_LLVM(core mcjit native linker instrumentation ipo vectorize irreader)
-   AC_DEFINE(ENABLE_LLVM_JIT, 1, [Define this to enable the LLVM JIT compiler])
+  if `${CC} --version | grep -q clang`; then
+    AX_LLVM(core mcjit native linker instrumentation ipo vectorize irreader)
+    AC_DEFINE(ENABLE_LLVM_JIT, 1, [Define this to enable the LLVM JIT compiler])
+    want_llvm_jit = yes
+  else
+    AC_MSG_WARN("clang compiler needed for llvm-jit")
+  fi
 fi
 AC_SUBST(ENABLE_LLVM_JIT)
-AM_CONDITIONAL(BUILD_LLVM_JIT, [test "${enable_llvm_jit}" = yes])
+AM_CONDITIONAL(BUILD_LLVM_JIT, [test "${want_llvm_jit}" = yes])
 
 ## rho provenance tracking.
 if test "${want_provenance_tracking}" = yes; then
@@ -2950,6 +2956,9 @@ fi
 
 if test "${want_provenance_tracking}" = yes; then
   R_SH_VAR_ADD(rho_options, [Provenance Tracking], [, ])
+fi
+if test "${enable_llvm_jit}" = yes; then
+  R_SH_VAR_ADD(rho_options, [LLVM JIT compiler], [, ])
 fi
 
 AC_MSG_RESULT(

--- a/configure.ac
+++ b/configure.ac
@@ -2959,6 +2959,8 @@ if test "${want_provenance_tracking}" = yes; then
 fi
 if test "${want_llvm_jit}" = yes; then
   R_SH_VAR_ADD(rho_options, [LLVM JIT compiler], [, ])
+else
+  R_SH_VAR_ADD(r_no_options, [LLVM JIT compiler], [, ])
 fi
 
 AC_MSG_RESULT(

--- a/configure.ac
+++ b/configure.ac
@@ -2371,12 +2371,12 @@ R_SYS_POSIX_LEAPSECONDS
 gl_STAT_TIME
 
 ## LLVM
-want_llvm_jit = no
+want_llvm_jit=no
 if test "${enable_llvm_jit}" = yes; then
   if `${CC} --version | grep -q clang`; then
     AX_LLVM(core mcjit native linker instrumentation ipo vectorize irreader)
     AC_DEFINE(ENABLE_LLVM_JIT, 1, [Define this to enable the LLVM JIT compiler])
-    want_llvm_jit = yes
+    want_llvm_jit=yes
   else
     AC_MSG_WARN("clang compiler needed for llvm-jit")
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -2957,7 +2957,7 @@ fi
 if test "${want_provenance_tracking}" = yes; then
   R_SH_VAR_ADD(rho_options, [Provenance Tracking], [, ])
 fi
-if test "${enable_llvm_jit}" = yes; then
+if test "${want_llvm_jit}" = yes; then
   R_SH_VAR_ADD(rho_options, [LLVM JIT compiler], [, ])
 fi
 

--- a/src/include/rho/ConsCell.hpp
+++ b/src/include/rho/ConsCell.hpp
@@ -106,17 +106,21 @@ namespace rho {
 		return m_cc;
 	    }
 
-	    ConsCell& operator++()
+	    iterator operator++()
 	    {
 		advance();
-		return *m_cc;
+		return *this;
 	    }
 
-	    ConsCell& operator++(int)
+	    iterator operator++(int)
 	    {
-		ConsCell& ans = *m_cc;
+		iterator ans = *this;
 		advance();
 		return ans;
+	    }
+
+	    bool operator==(ConsCell::iterator other) const {
+		return m_cc == other.m_cc;
 	    }
 	private:
 	    ConsCell* m_cc;
@@ -148,17 +152,21 @@ namespace rho {
 		return m_cc;
 	    }
 
-	    const ConsCell& operator++()
+	    const_iterator operator++()
 	    {
 		advance();
-		return *m_cc;
+		return *this;
 	    }
 
-	    const ConsCell& operator++(int)
+	    const_iterator operator++(int)
 	    {
-		const ConsCell& ans = *m_cc;
+		const_iterator ans = *this;
 		advance();
 		return ans;
+	    }
+
+	    bool operator==(ConsCell::const_iterator other) const {
+		return m_cc == other.m_cc;
 	    }
 	private:
 	    const ConsCell* m_cc;
@@ -345,20 +353,9 @@ namespace rho {
 	static void checkST(SEXPTYPE st);
     };
 
-    inline bool operator==(ConsCell::iterator l, ConsCell::iterator r)
-    {
-	return &(*l) == &(*r);
-    }
-
     inline bool operator!=(ConsCell::iterator l, ConsCell::iterator r)
     {
 	return !(l == r);
-    }
-
-    inline bool operator==(ConsCell::const_iterator l,
-			   ConsCell::const_iterator r)
-    {
-	return &(*l) == &(*r);
     }
 
     inline bool operator!=(ConsCell::const_iterator l,

--- a/src/include/rho/jit/Runtime.hpp
+++ b/src/include/rho/jit/Runtime.hpp
@@ -137,7 +137,7 @@ void emitIncrementNamed(llvm::Value* value, Compiler* compiler);
 // Exception handling code.
 // These functions currently don't have FunctionIds assigned.
 llvm::Type* exceptionInfoType(Compiler* compiler);
-llvm::Function* getExceptionPersonalityFunction();
+llvm::Function* getExceptionPersonalityFunction(Compiler* compiler);
 llvm::LandingPadInst* emitLandingPad(Compiler* compiler);
 
 llvm::Value* emitBeginCatch(llvm::Value* exception_reference,

--- a/src/include/rho/jit/Runtime.hpp
+++ b/src/include/rho/jit/Runtime.hpp
@@ -137,6 +137,7 @@ void emitIncrementNamed(llvm::Value* value, Compiler* compiler);
 // Exception handling code.
 // These functions currently don't have FunctionIds assigned.
 llvm::Type* exceptionInfoType(Compiler* compiler);
+llvm::Function* getExceptionPersonalityFunction();
 llvm::LandingPadInst* emitLandingPad(Compiler* compiler);
 
 llvm::Value* emitBeginCatch(llvm::Value* exception_reference,

--- a/src/main/ArgList.cpp
+++ b/src/main/ArgList.cpp
@@ -188,6 +188,9 @@ const RObject* ArgList::getTag(int position) const {
 }
 
 bool ArgList::has3Dots() const {
+  if (!list())
+    return false;
+
   for (const ConsCell& cell : *list()) {
     if (cell.car() == R_DotsSymbol)
       return true;

--- a/src/main/eval.cpp
+++ b/src/main/eval.cpp
@@ -779,7 +779,7 @@ static SEXP assignCall(SEXP op, SEXP symbol, SEXP fun,
 
 Rboolean asLogicalNoNA(SEXP s, SEXP call)
 {
-    Rboolean cond = RHOCONSTRUCT(Rboolean, NA_LOGICAL);
+    int cond = NA_LOGICAL;
 
     if (length(s) > 1)
     {
@@ -791,13 +791,13 @@ Rboolean asLogicalNoNA(SEXP s, SEXP call)
 	/* inline common cases for efficiency */
 	switch(TYPEOF(s)) {
 	case LGLSXP:
-	    cond = RHOCONSTRUCT(Rboolean, LOGICAL(s)[0]);
+	    cond = LOGICAL(s)[0];
 	    break;
 	case INTSXP:
-	    cond = RHOCONSTRUCT(Rboolean, INTEGER(s)[0]); /* relies on NA_INTEGER == NA_LOGICAL */
+	    cond = INTEGER(s)[0]; /* relies on NA_INTEGER == NA_LOGICAL */
 	    break;
 	default:
-	    cond = RHOCONSTRUCT(Rboolean, Rf_asLogical(s));
+	    cond = Rf_asLogical(s);
 	}
     }
 
@@ -808,7 +808,7 @@ Rboolean asLogicalNoNA(SEXP s, SEXP call)
 	    _("argument is of length zero");
 	Rf_errorcall(call, msg);
     }
-    return cond;
+    return static_cast<Rboolean>(cond);
 }
 
 

--- a/src/main/jit/CompiledExpression.cpp
+++ b/src/main/jit/CompiledExpression.cpp
@@ -68,6 +68,10 @@ CompiledExpression::CompiledExpression(const Closure* closure)
 	llvm::Function::ExternalLinkage,
 	"anonymous_function", // TODO: give it a useful name
 	module.get());
+#if (LLVM_VERSION > 306)
+    function->setPersonalityFn(Runtime::getExceptionPersonalityFunction());
+#endif
+
     Value* environment = &*(function->getArgumentList().begin());
     environment->setName("environment");
 

--- a/src/main/jit/CompiledExpression.cpp
+++ b/src/main/jit/CompiledExpression.cpp
@@ -94,8 +94,6 @@ CompiledExpression::CompiledExpression(const Closure* closure)
     // TODO: add optimization passes and re-verify.
 
     // The IR is now complete.  Compile to native code.
-    module->setTargetTriple(llvm::sys::getProcessTriple());
-
     llvm::TargetOptions options;
     // TODO(kmillar): set options dynamically.
     options.EnableFastISel = true;
@@ -111,7 +109,6 @@ CompiledExpression::CompiledExpression(const Closure* closure)
 #endif
 		   .setOptLevel(llvm::CodeGenOpt::None)
                    .setTargetOptions(options)
-                   .setMCPU(llvm::sys::getHostCPUName())
 		   .create());
     assert(m_engine);
 

--- a/src/main/jit/CompiledExpression.cpp
+++ b/src/main/jit/CompiledExpression.cpp
@@ -93,8 +93,6 @@ CompiledExpression::CompiledExpression(const Closure* closure)
 
     llvm::TargetOptions options;
     // TODO(kmillar): set options dynamically.
-    options.JITEmitDebugInfo = true;
-    options.NoFramePointerElim = true;
     options.EnableFastISel = true;
 
     m_engine.reset(

--- a/src/main/jit/CompiledExpression.cpp
+++ b/src/main/jit/CompiledExpression.cpp
@@ -68,9 +68,6 @@ CompiledExpression::CompiledExpression(const Closure* closure)
 	llvm::Function::ExternalLinkage,
 	"anonymous_function", // TODO: give it a useful name
 	module.get());
-#if (LLVM_VERSION > 306)
-    function->setPersonalityFn(Runtime::getExceptionPersonalityFunction());
-#endif
 
     Value* environment = &*(function->getArgumentList().begin());
     environment->setName("environment");
@@ -81,6 +78,10 @@ CompiledExpression::CompiledExpression(const Closure* closure)
     CompilerContext compiler_context(closure, environment, function,
 				     memory_manager.get());
     Compiler compiler(&compiler_context);
+#if (LLVM_VERSION > 306)
+    function->setPersonalityFn(
+        Runtime::getExceptionPersonalityFunction(&compiler));
+#endif
     Value* return_value = compiler.emitEval(body);
 
     if (!return_value->hasName())

--- a/src/main/jit/Makefile.in
+++ b/src/main/jit/Makefile.in
@@ -72,21 +72,20 @@ libjit.a: $(libjit_a_OBJECTS)
 	$(AR) cr $@ $(libjit_a_OBJECTS)
 	$(RANLIB) $@
 
-# Build the bytecode for the runtime module.  This is only enabled in
-# maintainer mode and requires CXX to be clang.
+# Build the bytecode for the runtime module.  This requires CXX to be clang
+# (checked in configure).
 #
 # This target doesn't really depend on RuntimeImpl.o, only the source files,
 # but since we generate dependency information for the object file, we use that
 # as a proxy for the source files.
 #
 # TODO(kmillar): -fno-use-cxa-atexit is needed due to LLVM bug #18062
-# TODO(kmillar): gracefully handle non-clang compilers.
-RuntimeImpl.bc: @MAINTAINER_MODE_TRUE@ RuntimeImpl.o
+RuntimeImpl.bc: RuntimeImpl.o
 	$(CXX) $(ALL_CPPFLAGS) $(ALL_CXXFLAGS) -fno-use-cxa-atexit \
 	  -emit-llvm -c $(top_srcdir)/src/main/jit/RuntimeImpl.cpp -o $@ 
 
 # This exists to create a human-readable version of the runtime IR code.
-RuntimeImpl.ll: @MAINTAINER_MODE_TRUE@ RuntimeImpl.o
+RuntimeImpl.ll: RuntimeImpl.o
 	$(CXX) $(ALL_CPPFLAGS) $(ALL_CXXFLAGS) -fno-use-cxa-atexit \
 	  -emit-llvm -S $(top_srcdir)/src/main/jit/RuntimeImpl.cpp -o $@ 
 

--- a/src/main/jit/Runtime.cpp
+++ b/src/main/jit/Runtime.cpp
@@ -190,7 +190,7 @@ Function* getExceptionPersonalityFunction(Compiler* compiler) {
 LandingPadInst* emitLandingPad(Compiler* compiler)
 {
   return compiler->CreateLandingPad(exceptionInfoType(compiler),
-#if (LLVM <= 306)
+#if (LLVM_VERSION <= 306)
                                     getExceptionPersonalityFunction(compiler),
 #endif
       0);

--- a/src/main/jit/Runtime.cpp
+++ b/src/main/jit/Runtime.cpp
@@ -183,14 +183,19 @@ Type* exceptionInfoType(Compiler* compiler)
 				 nullptr);
 }
 
+Function* getExceptionPersonalityFunction(Compiler* compiler) {
+  return getDeclaration("__gxx_personality_v0", compiler);
+}
+
 LandingPadInst* emitLandingPad(Compiler* compiler)
 {
-  Function* exception_personality_function
-      = getDeclaration("__gxx_personality_v0", compiler);
   return compiler->CreateLandingPad(exceptionInfoType(compiler),
-                                    exception_personality_function, 0);
+#if (LLVM <= 306)
+                                    getExceptionPersonalityFunction(),
+#endif
+      0);
 }
- 
+
 Value* emitBeginCatch(Value* exception_reference,
 		      Compiler* compiler)
 {

--- a/src/main/jit/Runtime.cpp
+++ b/src/main/jit/Runtime.cpp
@@ -191,7 +191,7 @@ LandingPadInst* emitLandingPad(Compiler* compiler)
 {
   return compiler->CreateLandingPad(exceptionInfoType(compiler),
 #if (LLVM <= 306)
-                                    getExceptionPersonalityFunction(),
+                                    getExceptionPersonalityFunction(compiler),
 #endif
       0);
 }

--- a/tests/rho/MCJITMemoryManagerTests.cpp
+++ b/tests/rho/MCJITMemoryManagerTests.cpp
@@ -33,6 +33,7 @@
 using namespace rho;
 using namespace rho::JIT;
 using namespace llvm;
+using rho::JIT::MCJITMemoryManager;
 
 class MCJITMemoryManagerTest : public ::testing::Test
 {

--- a/tests/rho/MCJITMemoryManagerTests.cpp
+++ b/tests/rho/MCJITMemoryManagerTests.cpp
@@ -33,7 +33,6 @@
 using namespace rho;
 using namespace rho::JIT;
 using namespace llvm;
-using rho::JIT::MCJITMemoryManager;
 
 class MCJITMemoryManagerTest : public ::testing::Test
 {
@@ -41,11 +40,11 @@ protected:
     MCJITMemoryManagerTest()
 	: m_context(getGlobalContext()),
 	  m_module(new Module("mcjit_mm_test", m_context)),
-	  m_manager(new MCJITMemoryManager(m_module.get())) { }
+	  m_manager(new rho::JIT::MCJITMemoryManager(m_module.get())) { }
 
     LLVMContext& m_context;
     std::unique_ptr<Module> m_module;
-    std::unique_ptr<MCJITMemoryManager> m_manager;
+    std::unique_ptr<rho::JIT::MCJITMemoryManager> m_manager;
 };
 
 


### PR DESCRIPTION
Adds the following compilers to the travis config:
  - gcc 4.9 (no longer an allowed failure)
  - gcc 5.0
  - clang 3.6
  - clang 3.7 (segfaults, tagged as allowed failure)
  - clang 3.8
  - clang 3.8 with asan
  - clang 3.8 with ubsan (segfaults, tagged as allowed failure)

Plus some minor code changes to make the code compile on those platforms and remove undefined behaviour.