### PR TITLE
Add internal allocstats function

### DIFF
--- a/src/include/rho/FixedVector.hpp
+++ b/src/include/rho/FixedVector.hpp
@@ -215,6 +215,7 @@ namespace rho {
 	    // this object, so account for it here.
 	    size_t bytes = (size() - 1) * sizeof(T);
 	    MemoryBank::adjustBytesAllocated(-bytes);
+            GCNode::adjustFreedSize(sizeof(FixedVector), bytes);
 	}
 
 	// Virtual function of GCNode:

--- a/src/include/rho/FixedVector.hpp
+++ b/src/include/rho/FixedVector.hpp
@@ -214,8 +214,9 @@ namespace rho {
 	    // GCNode::~GCNode doesn't know about the string storage space in
 	    // this object, so account for it here.
 	    size_t bytes = (size() - 1) * sizeof(T);
-	    MemoryBank::adjustBytesAllocated(-bytes);
-            GCNode::adjustFreedSize(sizeof(FixedVector), bytes);
+            if (bytes != 0) {
+                GCNode::adjustFreedSize(sizeof(FixedVector), sizeof(FixedVector) + bytes);
+            }
 	}
 
 	// Virtual function of GCNode:

--- a/src/include/rho/FixedVector.hpp
+++ b/src/include/rho/FixedVector.hpp
@@ -215,7 +215,7 @@ namespace rho {
 	    // this object, so account for it here.
 	    size_t bytes = (size() - 1) * sizeof(T);
             if (bytes != 0) {
-                GCNode::adjustFreedSize(sizeof(FixedVector), sizeof(FixedVector) + bytes);
+                MemoryBank::adjustFreedSize(sizeof(FixedVector), sizeof(FixedVector) + bytes);
             }
 	}
 

--- a/src/include/rho/GCNode.hpp
+++ b/src/include/rho/GCNode.hpp
@@ -244,12 +244,11 @@ namespace rho {
          * passed to the delete operator, causing inconsistent statistics for
          * free counts.
          *
-         * @param original The logged freed block size.
+         * @param original The previously logged freed block size.
          *
-         * @param change The change needed to update the freed block size to
-         * the actual size.
+         * @param actual The actual size of the freed block.
          */
-	static void adjustFreedSize(size_t original, size_t change);
+	static void adjustFreedSize(size_t original, size_t actual);
     protected:
 	/**
 	 * @note The destructor is protected to ensure that GCNode

--- a/src/include/rho/GCNode.hpp
+++ b/src/include/rho/GCNode.hpp
@@ -238,6 +238,18 @@ namespace rho {
 	// Otherwise returns nullptr.
 	static GCNode* asGCNode(void* candidate_pointer);
 
+        /** @brief Adjust the freed block statistics.
+         *
+         * This should be used when the entire size of a freed block is not
+         * passed to the delete operator, causing inconsistent statistics for
+         * free counts.
+         *
+         * @param original The logged freed block size.
+         *
+         * @param change The change needed to update the freed block size to
+         * the actual size.
+         */
+	static void adjustFreedSize(size_t original, size_t change);
     protected:
 	/**
 	 * @note The destructor is protected to ensure that GCNode

--- a/src/include/rho/GCNode.hpp
+++ b/src/include/rho/GCNode.hpp
@@ -237,18 +237,6 @@ namespace rho {
 	// returns the pointer to that node.
 	// Otherwise returns nullptr.
 	static GCNode* asGCNode(void* candidate_pointer);
-
-        /** @brief Adjust the freed block statistics.
-         *
-         * This should be used when the entire size of a freed block is not
-         * passed to the delete operator, causing inconsistent statistics for
-         * free counts.
-         *
-         * @param original The previously logged freed block size.
-         *
-         * @param actual The actual size of the freed block.
-         */
-	static void adjustFreedSize(size_t original, size_t actual);
     protected:
 	/**
 	 * @note The destructor is protected to ensure that GCNode

--- a/src/include/rho/MemoryBank.hpp
+++ b/src/include/rho/MemoryBank.hpp
@@ -35,6 +35,8 @@
 #include "rho/CellPool.hpp"
 #include "rho/SEXPTYPE.hpp"
 
+#define ALLOC_STATS // TODO(joqvist): Make this a configure option?
+
 namespace rho {
     /** @brief Class to manage memory allocation and deallocation for rho.
      * 

--- a/src/include/rho/MemoryBank.hpp
+++ b/src/include/rho/MemoryBank.hpp
@@ -142,23 +142,26 @@ namespace rho {
 #endif
 
 	friend class GCNode;
-	static void notifyAllocation(size_t bytes)
-	{
-#ifdef R_MEMORY_PROFILING
-	    if (s_monitor && bytes >= s_monitor_threshold) s_monitor(bytes);
-#endif
-	    ++s_blocks_allocated;
-	    s_bytes_allocated += bytes;
-	}
+	static void notifyAllocation(size_t bytes);
 
-	static void notifyDeallocation(size_t bytes) {
-	    s_bytes_allocated -= bytes;
-	    --s_blocks_allocated;
-	}
+	static void notifyDeallocation(size_t bytes);
 
 	friend class String;
 	template<typename, SEXPTYPE, typename>
 	friend class FixedVector;
+
+        /** @brief Adjust the freed block statistics.
+         *
+         * This should be used when the entire size of a freed block is not
+         * passed to the delete operator, causing inconsistent statistics for
+         * free counts.
+         *
+         * @param original The previously logged freed block size.
+         *
+         * @param actual The actual size of the freed block.
+         */
+	static void adjustFreedSize(size_t original, size_t actual);
+
 	static void adjustBytesAllocated(size_t bytes) {
 	    s_bytes_allocated += bytes;
 	}

--- a/src/library/base/R/allocstats.R
+++ b/src/library/base/R/allocstats.R
@@ -1,0 +1,29 @@
+#  R : A Computer Language for Statistical Data Analysis
+#  Copyright (C) 2016 and onwards the Rho Project Authors.
+#
+#  Rho is not part of the R project, and bugs and other issues should
+#  not be reported via r-bugs or other R project channels; instead refer
+#  to the Rho website.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, a copy is available at
+#  https://www.R-project.org/Licenses/
+
+# Builds a data frame with current allocation statistics.
+.allocstats <- function() {
+    stats <- data.frame(.Call('allocstats', PACKAGE='base'))
+    colnames(stats) <- c('size', 'alloc', 'free')
+    stats$live <- (stats$alloc - stats$free) * stats$size # Live bytes.
+    stats$percent <- as.numeric(100 * stats$live / sum(stats$live))
+    stats
+}

--- a/src/main/GCNode.cpp
+++ b/src/main/GCNode.cpp
@@ -35,16 +35,13 @@
 #include <cstdlib>
 #include <iostream>
 #include <limits>
-#include <iterator>
 #include "rho/AddressSanitizer.hpp"
 #include "rho/GCManager.hpp"
 #include "rho/GCRoot.hpp"
 #include "rho/GCStackFrameBoundary.hpp"
-#include "rho/GCStackRoot.hpp"
 #include "rho/ProtectStack.hpp"
 #include "rho/RAllocStack.hpp"
 #include "rho/WeakRef.hpp"
-#include "rho/ListVector.hpp"
 #include "gc.h"
 extern "C" {
 #  include "private/gc_priv.h"
@@ -70,15 +67,6 @@ static const int kRedzoneSize = 16;
 #else
 static const int kRedzoneSize = 0;
 #endif  // HAVE_ADDRESS_SANITIZER
-
-#define ALLOC_STATS // Make this a configure option?
-#ifdef ALLOC_STATS
-// Allocation and free frequency tables for profiling the allocator.
-// Allocation stats are collected into 8-byte bins, allocations > 256 bytes are
-// counted in the 256 byte bin.
-static size_t alloc_counts[32];
-static size_t free_counts[32];
-#endif
 
 static void* offset(void* p, size_t bytes) {
     return static_cast<char*>(p) + bytes;
@@ -106,27 +94,11 @@ static bool test_allocated_bit(void* allocation) {
     return GC_is_marked(allocation);
 }
 
-// Computes the bin to update in an allocation frequency table.
-static int get_bin_number(size_t bytes) {
-    size_t bin;
-    assert(bytes >= 8);
-    if (bytes >= 32 * 8) {
-        bin = 31;
-    } else {
-        bin = (31 & (bytes / 8)) - 1;
-    }
-    return bin;
-}
-
 HOT_FUNCTION void* GCNode::operator new(size_t bytes)
 {
     GCManager::maybeGC();
     MemoryBank::notifyAllocation(bytes);
     void *result;
-
-#ifdef ALLOC_STATS
-    alloc_counts[get_bin_number(bytes)] += 1;
-#endif
 
 #ifdef HAVE_ADDRESS_SANITIZER
     result = asan_allocate(bytes);
@@ -154,24 +126,11 @@ void GCNode::operator delete(void* p, size_t bytes)
 {
     MemoryBank::notifyDeallocation(bytes);
 
-#ifdef ALLOC_STATS
-    free_counts[get_bin_number(bytes)] += 1;
-#endif
-
 #ifdef HAVE_ADDRESS_SANITIZER
     asan_free(p);
 #else
     clear_allocated_bit(p);
     GC_free(p);
-#endif
-}
-
-void GCNode::adjustFreedSize(size_t original, size_t actual)
-{
-    MemoryBank::adjustBytesAllocated(original - actual);
-#ifdef ALLOC_STATS
-    free_counts[get_bin_number(original)] -= 1;
-    free_counts[get_bin_number(actual)] += 1;
 #endif
 }
 
@@ -479,35 +438,3 @@ static void asan_free(void* object) {
 }
 
 #endif  // HAVE_ADDRESS_SANITIZER
-
-// Returns a vector list with columns 'size', 'alloc', 'free' representing alloc and free stats.
-extern "C"
-SEXP allocstats(void) {
-#ifdef ALLOC_STATS
-
-    // Copy frequency tables to avoid concurrent modifications affecting result.
-    size_t allocs[32];
-    size_t frees[32];
-    std::copy(std::begin(alloc_counts), std::end(alloc_counts), std::begin(allocs));
-    std::copy(std::begin(free_counts), std::end(free_counts), std::begin(frees));
-
-    GCStackRoot<ListVector> ans(ListVector::create(3));
-    GCStackRoot<IntVector> size_column(IntVector::create(32));
-    GCStackRoot<IntVector> alloc_column(IntVector::create(32));
-    GCStackRoot<IntVector> free_column(IntVector::create(32));
-
-    // Iterate the allocation table because its key set is a superset of the free table key set.
-    for (int i = 0; i < 32; ++i) {
-        size_t size = (i + 1) * 8;
-        (*size_column)[i] = size;
-        (*alloc_column)[i] = allocs[i];
-        (*free_column)[i] = frees[i];
-    }
-    (*ans)[0] = size_column.get();
-    (*ans)[1] = alloc_column.get();
-    (*ans)[2] = free_column.get();
-    return ans;
-#else
-    return nullptr;
-#endif // ALLOC_STATS
-}

--- a/src/main/Makefile.in
+++ b/src/main/Makefile.in
@@ -31,7 +31,7 @@ SOURCES_C = complex.c inlined.c radixsort.c \
 	g_alab_her.c g_cntrlify.c g_fontdb.c g_her_glyph.c
 
 SOURCES_CXX = \
-	ArgList.cpp ArgMatcher.cpp \
+	allocstats.cpp ArgList.cpp ArgMatcher.cpp \
 	BinaryFunction.cpp Browser.cpp BuiltInFunction.cpp \
 	CellPool.cpp Closure.cpp \
 	ClosureContext.cpp CommandChronicle.cpp CommandLineArgs.cpp \

--- a/src/main/String.cpp
+++ b/src/main/String.cpp
@@ -110,7 +110,7 @@ String::~String()
     // GCNode::~GCNode doesn't know about the string storage space in this
     // object, so account for it here.
     size_t bytes = size() + 1;
-    GCNode::adjustFreedSize(sizeof(String), sizeof(String) + bytes);
+    MemoryBank::adjustFreedSize(sizeof(String), sizeof(String) + bytes);
 }
 
 namespace {

--- a/src/main/String.cpp
+++ b/src/main/String.cpp
@@ -110,8 +110,7 @@ String::~String()
     // GCNode::~GCNode doesn't know about the string storage space in this
     // object, so account for it here.
     size_t bytes = size() + 1;
-    MemoryBank::adjustBytesAllocated(-bytes);
-    GCNode::adjustFreedSize(sizeof(String), bytes);
+    GCNode::adjustFreedSize(sizeof(String), sizeof(String) + bytes);
 }
 
 namespace {

--- a/src/main/String.cpp
+++ b/src/main/String.cpp
@@ -111,6 +111,7 @@ String::~String()
     // object, so account for it here.
     size_t bytes = size() + 1;
     MemoryBank::adjustBytesAllocated(-bytes);
+    GCNode::adjustFreedSize(sizeof(String), bytes);
 }
 
 namespace {

--- a/src/main/allocstats.cpp
+++ b/src/main/allocstats.cpp
@@ -1,0 +1,63 @@
+/*
+ *  R : A Computer Language for Statistical Data Analysis
+ *  Copyright (C) 2016 and onwards the Rho Project Authors.
+ *
+ *  Rho is not part of the R project, and bugs and other issues should
+ *  not be reported via r-bugs or other R project channels; instead refer
+ *  to the Rho website.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, a copy is available at
+ *  https://www.R-project.org/Licenses/
+ */
+
+#include "rho/IntVector.hpp"
+#include "rho/GCStackRoot.hpp"
+#include "rho/MemoryBank.hpp"
+
+using namespace rho;
+
+#ifdef ALLOC_STATS
+extern size_t alloc_counts[32];
+extern size_t free_counts[32];
+#endif
+
+// Returns a vector list with columns 'size', 'alloc', 'free' representing alloc and free stats.
+extern "C"
+SEXP allocstats(void) {
+#ifdef ALLOC_STATS
+
+    // Copy frequency tables to avoid concurrent modifications affecting result.
+    size_t allocs[32];
+    size_t frees[32];
+    std::copy(std::begin(alloc_counts), std::end(alloc_counts), std::begin(allocs));
+    std::copy(std::begin(free_counts), std::end(free_counts), std::begin(frees));
+
+    GCStackRoot<ListVector> ans(ListVector::create(3));
+    GCStackRoot<IntVector> size_column(IntVector::create(32));
+    GCStackRoot<IntVector> alloc_column(IntVector::create(32));
+    GCStackRoot<IntVector> free_column(IntVector::create(32));
+
+    for (int i = 0; i < 32; ++i) {
+        (*size_column)[i] = (i + 1) * 8;
+        (*alloc_column)[i] = allocs[i];
+        (*free_column)[i] = frees[i];
+    }
+    (*ans)[0] = size_column.get();
+    (*ans)[1] = alloc_column.get();
+    (*ans)[2] = free_column.get();
+    return ans;
+#else
+    return nullptr;
+#endif // ALLOC_STATS
+}

--- a/src/main/basedecl.h
+++ b/src/main/basedecl.h
@@ -37,6 +37,7 @@ extern "C" {
 SEXP R_getTaskCallbackNames(void);
 SEXP R_removeTaskCallback(SEXP);
 SEXP R_addTaskCallback(SEXP, SEXP, SEXP, SEXP);
+SEXP allocstats(void);
 
 
 #ifdef __cplusplus

--- a/src/main/registration.cpp
+++ b/src/main/registration.cpp
@@ -75,6 +75,7 @@ static R_CallMethodDef callMethods [] = {
     CALLDEF(R_addTaskCallback, 4),
     CALLDEF(R_getTaskCallbackNames, 0),
     CALLDEF(R_removeTaskCallback, 1),
+    CALLDEF(allocstats, 0),
 
     {nullptr, nullptr, 0}
 };


### PR DESCRIPTION
This adds a .Call function called "allocstats" that can be used to
get allocation statistics. It returns a list vector of three columns:
allocation size, number of allocations, and number of frees.