### PR TITLE
Add benchmarking script

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,3 +1,4 @@
 /benchmarks/
 /rho/
 /out/
+/Rplots.pdf

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,3 @@
+/benchmarks/
+/rho/
+/out/

--- a/bench/report.R
+++ b/bench/report.R
@@ -3,40 +3,53 @@
 library(methods)
 library(ggplot2)
 
-read.stats <- function(id, version) {
+read.stats <- function(id, version, timestamp) {
     filename <- paste('out/', id, '-', version, '.csv', sep='')
     df <- read.csv(filename)
     df$id <- id
     df$version <- version
+    df$timestamp <- strptime(timestamp, "%Y-%m-%d %H:%M:%S")
     df
 }
 
-merge.stats <- function(prev, id, version) {
+merge.stats <- function(prev, id, version, timestamp) {
     if (is.data.frame(prev)) {
-        rbind(prev, read.stats(id, version))
+        rbind(prev, read.stats(id, version, timestamp))
     } else {
-        read.stats(id, version)
+        read.stats(id, version, timestamp)
     }
 }
 
 versions <- read.csv('out/versions', header=F)
+colnames(versions) <- c('commit', 'timestamp')
 cr <- NA
 cr.jit <- NA
 rho <- NA
 rho.jit <- NA
-for (v in versions$V1) {
-    cr <- merge.stats(cr, 'cr', v)
-    cr.jit <- merge.stats(cr.jit, 'cr-jit', v)
-    rho <- merge.stats(rho, 'rho', v)
-    rho.jit <- merge.stats(rho.jit, 'rho-jit', v)
+for (i in seq_len(nrow(versions))) {
+    commit <- versions$commit[i]
+    timestamp <- versions$timestamp[i]
+    cr <- merge.stats(cr, 'cr', commit, timestamp)
+    cr.jit <- merge.stats(cr.jit, 'cr-jit', commit, timestamp)
+    rho <- merge.stats(rho, 'rho', commit, timestamp)
+    rho.jit <- merge.stats(rho.jit, 'rho-jit', commit, timestamp)
 }
 
-cols <- c('benchmark', 'id', 'version', 'time')
+cols <- c('benchmark', 'id', 'version', 'timestamp', 'time')
 report <- rbind(cr[cols], cr.jit[cols], rho[cols], rho.jit[cols])
-ggplot(report, aes(x=version, y=time)) + geom_bar(aes(fill=id), position='dodge', stat='identity') + labs(title='Totals')
+
+# Sort versions by timestamp.
+report <- report[order(report$timestamp),]
+report$version <- factor(report$version, unique(report$version))
+
+ggplot(report, aes(x=version, y=time)) +
+    geom_bar(aes(fill=id), position='dodge', stat='identity') +
+    labs(title='Totals')
 
 single_report <- function(bm) {
-    ggplot(subset(report, benchmark == bm), aes(x=version, y=time)) + geom_bar(aes(fill=id), position='dodge', stat='identity') + labs(title=bm)
+    ggplot(subset(report, benchmark == bm), aes(x=version, y=time)) +
+        geom_bar(aes(fill=id), position='dodge', stat='identity') +
+        labs(title=bm)
 }
 single_report('crt.R')
 single_report('fib.R')

--- a/bench/report.R
+++ b/bench/report.R
@@ -2,6 +2,8 @@
 
 library(methods)
 library(ggplot2)
+library(grid)
+library(gridExtra)
 
 read.stats <- function(id, version, timestamp) {
     filename <- paste('out/', id, '-', version, '.csv', sep='')
@@ -42,6 +44,8 @@ report <- rbind(cr[cols], cr.jit[cols], rho[cols], rho.jit[cols])
 report <- report[order(report$timestamp),]
 report$version <- factor(report$version, unique(report$version))
 
+pdf('report.pdf')
+
 ggplot(report, aes(x=version, y=time)) +
     geom_bar(aes(fill=id), position='dodge', stat='identity') +
     labs(title='Totals')
@@ -58,3 +62,19 @@ single_report('gcd.R')
 single_report('gcd_rec.R')
 single_report('prime.R')
 single_report('ForLoopAdd.R')
+invisible(dev.off())
+
+pdf('tables.pdf')
+single_table <- function(bm) {
+    report.subset <- subset(report[c('benchmark', 'id', 'version', 'time')], benchmark == bm)
+    grid.table(reshape(report.subset, timevar='id', idvar=c('benchmark', 'version'), direction='wide'))
+    grid.newpage()
+}
+single_table('crt.R')
+single_table('fib.R')
+single_table('fib_rec.R')
+single_table('gcd.R')
+single_table('gcd_rec.R')
+single_table('prime.R')
+single_table('ForLoopAdd.R')
+invisible(dev.off())

--- a/bench/report.R
+++ b/bench/report.R
@@ -1,5 +1,6 @@
 # Builds benchmark report.
 
+library(methods)
 library(ggplot2)
 
 read.stats <- function(id, version) {
@@ -32,4 +33,15 @@ for (v in versions$V1) {
 
 cols <- c('benchmark', 'id', 'version', 'time')
 report <- rbind(cr[cols], cr.jit[cols], rho[cols], rho.jit[cols])
-ggplot(report, aes(x=version, y=time)) + geom_bar(aes(fill=id), position='dodge', stat='identity')
+ggplot(report, aes(x=version, y=time)) + geom_bar(aes(fill=id), position='dodge', stat='identity') + labs(title='Totals')
+
+single_report <- function(bm) {
+    ggplot(subset(report, benchmark == bm), aes(x=version, y=time)) + geom_bar(aes(fill=id), position='dodge', stat='identity') + labs(title=bm)
+}
+single_report('crt.R')
+single_report('fib.R')
+single_report('fib_rec.R')
+single_report('gcd.R')
+single_report('gcd_rec.R')
+single_report('prime.R')
+single_report('ForLoopAdd.R')

--- a/bench/report.R
+++ b/bench/report.R
@@ -1,0 +1,35 @@
+# Builds benchmark report.
+
+library(ggplot2)
+
+read.stats <- function(id, version) {
+    filename <- paste('out/', id, '-', version, '.csv', sep='')
+    df <- read.csv(filename)
+    df$id <- id
+    df$version <- version
+    df
+}
+
+merge.stats <- function(prev, id, version) {
+    if (is.data.frame(prev)) {
+        rbind(prev, read.stats(id, version))
+    } else {
+        read.stats(id, version)
+    }
+}
+
+versions <- read.csv('out/versions', header=F)
+cr <- NA
+cr.jit <- NA
+rho <- NA
+rho.jit <- NA
+for (v in versions$V1) {
+    cr <- merge.stats(cr, 'cr', v)
+    cr.jit <- merge.stats(cr.jit, 'cr-jit', v)
+    rho <- merge.stats(rho, 'rho', v)
+    rho.jit <- merge.stats(rho.jit, 'rho-jit', v)
+}
+
+cols <- c('benchmark', 'id', 'version', 'time')
+report <- rbind(cr[cols], cr.jit[cols], rho[cols], rho.jit[cols])
+ggplot(report, aes(x=version, y=time)) + geom_bar(aes(fill=id), position='dodge', stat='identity')

--- a/bench/runbench.py
+++ b/bench/runbench.py
@@ -1,0 +1,166 @@
+#!/usr/bin/python
+
+#  R : A Computer Language for Statistical Data Analysis
+#  Copyright (C) 2016 and onwards the Rho Project Authors.
+#
+#  Rho is not part of the R project, and bugs and other issues should
+#  not be reported via r-bugs or other R project channels; instead refer
+#  to the Rho website.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, a copy is available at
+#  https://www.R-project.org/Licenses/
+
+# This script benchmarks a specific version of Rho and outputs the result in a
+# file in the output directory.
+#
+# 1. Take Rho git ref (hash) on command line to select version.
+# 2. Check out the selected Rho version into local rho directory.
+# 3. Build the Rho version.
+# 4. Run benchmarks and collect results into output directory.
+#
+# Output is generated into files with the naming scheme out/rho(-jit)?-GITREF.csv
+# where GITREF is the Git reference. For each benchmark run, CR is also benchmarked
+# to get a performance baseline.
+
+import os
+import subprocess
+import argparse
+import ConfigParser
+
+from os.path import normpath
+
+# This list contains benchmarks to run and the number of warmup/bench runs for each.
+# Various numbers of runs are used for the benchmarks to ensure that
+# short-running benchmarks run enough iterations to not be strongly affected by
+# VM startup time.
+benchmarks = [
+        { 'name': 'benchmarks/scalar/crt/crt.R', 'warmup_rep': 10, 'bench_rep': 30 },
+        { 'name': 'benchmarks/scalar/fib/fib.R', 'warmup_rep': 4, 'bench_rep': 12 },
+        { 'name': 'benchmarks/scalar/fib/fib_rec.R', 'warmup_rep': 2, 'bench_rep': 5 },
+        { 'name': 'benchmarks/scalar/gcd/gcd.R', 'warmup_rep': 2, 'bench_rep': 5 },
+        { 'name': 'benchmarks/scalar/gcd/gcd_rec.R', 'warmup_rep': 2000, 'bench_rep': 5000 },
+        { 'name': 'benchmarks/scalar/prime/prime.R', 'warmup_rep': 2, 'bench_rep': 3 },
+        { 'name': 'benchmarks/scalar/ForLoopAdd/ForLoopAdd.R', 'warmup_rep': 2, 'bench_rep': 3 },
+        { 'name': 'benchmarks/scalar/ForLoopAdd/ForLoopAdd.R', 'warmup_rep': 2, 'bench_rep': 3 },
+        ]
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='''Runs R benchmarks for a specific version of Rho.''')
+    parser.add_argument('gitref', help='The Rho git reference to benchmark')
+    parser.add_argument(
+            '--repository', default='git@github.com:rho-devel/rho',
+            help='The git repository to clone from')
+    parser.add_argument(
+            '--build_dir', default='rho',
+            help='The directory to build Rho in. The Rho repository is cloned into this directory.')
+    parser.add_argument('--result_dir', default='out',
+            help='The output directory to store benchmark results in')
+    args = parser.parse_args()
+    return args
+
+# Set up RVM parameters to run Gnu R.
+def use_cr(jit):
+    if jit:
+        return { 'name': 'R-bytecode', 'id': 'cr-jit', 'jit': True }
+    else:
+        return { 'name': 'R', 'id': 'cr', 'jit': False }
+
+def build_rho(args, jit, build=True):
+    bench_dir = os.getcwd()
+    rvm = { 'name': 'Rho', 'jit': jit }
+    if jit:
+        rvm['id'] = 'rho-jit'
+    else:
+        rvm['id'] = 'rho'
+    try:
+        os.chdir(args.build_dir)
+        if not os.path.isdir('.git'):
+            # Clone Rho into the local directory.
+            exit_code = subprocess.call(['git', 'clone', args.repository, '.'])
+        # Clean and switch to the selected revision.
+        subprocess.call(['git', 'reset', '--hard', args.gitref])
+        # Build with JIT enabled.
+        subprocess.call(['git', 'clean', '-fd', 'HEAD'])
+        subprocess.call(['git', 'clean', '-fX', 'HEAD'])
+        if build:
+            subprocess.call(['tools/rsync-recommended'])
+            if jit:
+                subprocess.call(['./configure', '--with-blas', '--with-lapack', '--enable-llvm-jit'])
+            else:
+                subprocess.call(['./configure', '--with-blas', '--with-lapack'])
+            subprocess.call(['make', '-j2'])
+    finally:
+        os.chdir(bench_dir)
+    # Create a new config file because the benchmark suite is not aware of our
+    # Rho build.
+    rvm['cfg_file'] = write_config(args, rvm)
+    return rvm
+
+def write_config(args, rvm):
+    config = ConfigParser.RawConfigParser()
+    config.add_section('GENERAL')
+    config.set('GENERAL', 'WARMUP_REP', 2)
+    config.set('GENERAL', 'BENCH_REP', 5)
+    config.set('GENERAL', 'PERF_TMP', '_perf.tmp')
+    config.set('GENERAL', 'PERF_REP', 1)
+    config.set('GENERAL', 'PERF_CMD', 'perf stat -r %(PERF_REP)s -x, -o %(PERF_TMP)s --append')
+    config.add_section('Rho')
+    if rvm['jit']:
+        config.set('Rho', 'ENV', 'R_COMPILE_PKGS=1 R_ENABLE_JIT=2')
+        config.set('Rho', 'HARNESS_ARGS', 'TRUE')
+    else:
+        config.set('Rho', 'ENV', 'R_COMPILE_PKGS=0 R_ENABLE_JIT=0')
+        config.set('Rho', 'HARNESS_ARGS', 'FALSE')
+#HOME=
+    config.set('Rho', 'HOME', os.path.realpath('%s/bin' % args.build_dir))
+    config.set('Rho', 'CMD', 'Rscript')
+    config.set('Rho', 'ARGS', '--vanilla')
+    config.set('Rho', 'HARNESS', 'r_harness.R')
+    cfg_file = normpath('%s/rho.cfg' % args.result_dir)
+    with open(cfg_file, 'wb') as f:
+        config.write(f)
+    return cfg_file
+
+def bench(args, rvm):
+    for bm in benchmarks:
+        bench_cmd = [
+                'python', normpath('benchmarks/utility/rbench.py'),
+                normpath(bm['name']),
+                '--rvm', rvm['name'],
+                '--warmup_rep', "%d" % bm['warmup_rep'],
+                '--bench_rep', "%d" % bm['bench_rep'],
+                '--timingfile',
+                normpath('%s/%s-%s.csv' % (args.result_dir, rvm['id'], args.gitref))]
+        if 'cfg_file' in rvm:
+            bench_cmd = bench_cmd + ['--config', rvm['cfg_file']]
+        subprocess.call(bench_cmd)
+
+def main():
+    args = parse_args()
+    if not os.path.isdir('benchmarks'):
+        # Clone the benchmark suite.
+        subprocess.call(['git', 'clone', 'git@github.com:llbit/rbenchmarks.git', 'benchmarks'])
+    if not os.path.isdir(args.build_dir):
+        os.mkdir(args.build_dir)
+    if not os.path.isdir(args.result_dir):
+        os.mkdir(args.result_dir)
+    # Build and benchmark Rho.
+    bench(args, build_rho(args, jit=False))
+    bench(args, build_rho(args, jit=True))
+    # Also run CR to get a baseline for performance.
+    bench(args, use_cr(jit=False))
+    bench(args, use_cr(jit=True))
+
+if __name__ == "__main__":
+	main()

--- a/bench/runbench.py
+++ b/bench/runbench.py
@@ -178,7 +178,7 @@ def bench(gitref, args, rvm):
 # Set up the benchmark suite. Generates input data for the benchmarks that need input data.
 def setup_benchmarks():
     # Clone the benchmark suite.
-    subprocess.call(['git', 'clone', 'git@github.com:llbit/rbenchmarks.git', 'benchmarks'])
+    subprocess.call(['git', 'clone', 'git@github.com:rho-devel/benchmarks.git', 'benchmarks'])
     bench_dir = os.getcwd()
     try:
         # Generate benchmark input data.


### PR DESCRIPTION
This adds a Python script (bench/runbench.py) for benchmarking Rho. The
script attempts to automate the building and benchmarking of a specific
version of Rho. The goal is to make it simpler to gather performance
metrics and reduce the risk for human error affecting benchmark results.

The benchmark script takes as argument a Git reference for the version
of Rho to benchmark, it also benchmarks CR as a baseline for performance
comparison.