### PR TITLE
Updated benchmark set and benchmark report script

### DIFF
--- a/bench/runbench.py
+++ b/bench/runbench.py
@@ -55,7 +55,8 @@ benchmarks = [
         { 'name': 'benchmarks/shootout/nbody/nbody.R', 'warmup_rep': 0, 'bench_rep': 1 },
         { 'name': 'benchmarks/shootout/fannkuch-redux/fannkuch-redux.R', 'warmup_rep': 0, 'bench_rep': 1 },
         { 'name': 'benchmarks/shootout/spectral-norm/spectral-norm.R', 'warmup_rep': 0, 'bench_rep': 1 },
-        { 'name': 'benchmarks/shootout/mandelbrot/mandelbrot.R', 'warmup_rep': 0, 'bench_rep': 1 },
+        # Skip mandelbrot.R to avoid duplicate benchmark IDs (conflicts with riposte/mandelbrot.R).
+        #{ 'name': 'benchmarks/shootout/mandelbrot/mandelbrot.R', 'warmup_rep': 0, 'bench_rep': 1 },
         { 'name': 'benchmarks/shootout/pidigits/pidigits.R', 'warmup_rep': 0, 'bench_rep': 1 },
         { 'name': 'benchmarks/riposte/black_scholes.R', 'warmup_rep': 0, 'bench_rep': 1 },
         { 'name': 'benchmarks/riposte/cleaning.R', 'warmup_rep': 0, 'bench_rep': 1 },
@@ -68,7 +69,8 @@ benchmarks = [
         { 'name': 'benchmarks/riposte/mandelbrot.R', 'warmup_rep': 0, 'bench_rep': 1 },
         { 'name': 'benchmarks/riposte/pca.R', 'warmup_rep': 0, 'bench_rep': 1 },
         { 'name': 'benchmarks/riposte/pca-blocked.R', 'warmup_rep': 0, 'bench_rep': 1 },
-        { 'name': 'benchmarks/riposte/qr.R', 'warmup_rep': 0, 'bench_rep': 1 },
+        # Skip qr.R because it fails to run (missing strip function).
+        #{ 'name': 'benchmarks/riposte/qr.R', 'warmup_rep': 0, 'bench_rep': 1 },
         { 'name': 'benchmarks/riposte/raysphere.R', 'warmup_rep': 0, 'bench_rep': 1 },
         { 'name': 'benchmarks/riposte/sample_builtin.R', 'warmup_rep': 0, 'bench_rep': 1 },
         { 'name': 'benchmarks/riposte/sample.R', 'warmup_rep': 0, 'bench_rep': 1 },


### PR DESCRIPTION
The benchmark report script now generates one graph for each benchmark.
Also added a command line argument to specify an alternate output
directory for the report script.

Added generation of tables.pdf with detailed statistics for each
benchmark.

Filtered out qr.R because it fails to run, and
shootout/mandelbrot/mandelbrot.R because it conflicts with
riposte/mandelbrot.R.