### PR TITLE
Separate counting marker GCNode::CountingMarker

### DIFF
--- a/src/include/rho/GCNode.hpp
+++ b/src/include/rho/GCNode.hpp
@@ -265,7 +265,15 @@ namespace rho {
 	 */
 	class Marker : public const_visitor {
 	public:
-	    Marker()
+	    // Virtual function of const_visitor:
+	    void operator()(const GCNode* node) override;
+	};
+
+	/** Marker that counts the number of nodes marked.
+	 */
+	class CountingMarker : public Marker {
+	public:
+	    CountingMarker()
 		: m_marks_applied(0)
 	    {}
 
@@ -274,7 +282,6 @@ namespace rho {
 		return m_marks_applied;
 	    }
 
-	    // Virtual function of const_visitor:
 	    void operator()(const GCNode* node) override;
 	private:
 	    unsigned int m_marks_applied;

--- a/src/main/GCNode.cpp
+++ b/src/main/GCNode.cpp
@@ -340,11 +340,8 @@ void GCNode::CountingMarker::operator()(const GCNode* node)
     if (node->isMarked()) {
 	return;
     }
-    // Update mark  Beware ~ promotes to unsigned int.
-    node->m_rcmms &= static_cast<unsigned char>(~s_mark_mask);
-    node->m_rcmms |= s_mark;
+    Marker::operator()(node);
     m_marks_applied += 1;
-    node->visitReferents(this);
 }
 
 void rho::initializeMemorySubsystem()

--- a/src/main/GCNode.cpp
+++ b/src/main/GCNode.cpp
@@ -332,7 +332,18 @@ void GCNode::Marker::operator()(const GCNode* node)
     // Update mark  Beware ~ promotes to unsigned int.
     node->m_rcmms &= static_cast<unsigned char>(~s_mark_mask);
     node->m_rcmms |= s_mark;
-    ++m_marks_applied;
+    node->visitReferents(this);
+}
+
+void GCNode::CountingMarker::operator()(const GCNode* node)
+{
+    if (node->isMarked()) {
+	return;
+    }
+    // Update mark  Beware ~ promotes to unsigned int.
+    node->m_rcmms &= static_cast<unsigned char>(~s_mark_mask);
+    node->m_rcmms |= s_mark;
+    m_marks_applied += 1;
     node->visitReferents(this);
 }
 

--- a/src/main/WeakRef.cpp
+++ b/src/main/WeakRef.cpp
@@ -215,7 +215,7 @@ void WeakRef::markThru()
     {
 	unsigned int marks_applied;
 	do {
-	    GCNode::Marker marker;
+	    GCNode::CountingMarker marker;
 	    WRList::iterator lit = live->begin();
 	    while (lit != live->end()) {
 		WeakRef* wr = *lit++;


### PR DESCRIPTION
This splits out the counting feature of GCNode::Marker into a separate
derived class.