### PR TITLE
Remove redundant on stack test

### DIFF
--- a/src/include/rho/GCNode.hpp
+++ b/src/include/rho/GCNode.hpp
@@ -422,7 +422,8 @@ namespace rho {
 	    return (m_rcmms & s_mark_mask) == s_mark;
 	}
 
-	// Mark this node as moribund:
+	/** @brief Mark this node as moribund or delete if the stack bit is correct.
+         */
 	void makeMoribund() const HOT_FUNCTION;
 
 	void addToMoribundList() const HOT_FUNCTION;

--- a/src/include/rho/GCNode.hpp
+++ b/src/include/rho/GCNode.hpp
@@ -376,9 +376,12 @@ namespace rho {
 
 	void clearOnStackBit() const {
 	    m_rcmms = m_rcmms & static_cast<unsigned char>(~s_on_stack_mask);
-	    if ((m_rcmms &
-		 (s_refcount_mask | s_on_stack_mask| s_moribund_mask)) == 0)
-		makeMoribund();
+	    if ((m_rcmms & (s_refcount_mask | s_moribund_mask)) == 0) {
+                // Clearing stack bits only happens when removing a stack barrier, so
+                // the object still exists on the stack and we can only add it to the
+                // moribund list here.
+                addToMoribundList();
+            }
 	}
 
 	bool isOnStackBitSet() const {
@@ -421,6 +424,8 @@ namespace rho {
 
 	// Mark this node as moribund:
 	void makeMoribund() const HOT_FUNCTION;
+
+	void addToMoribundList() const HOT_FUNCTION;
 
 	/** @brief Carry out the mark phase of garbage collection.
 	 */

--- a/src/main/GCNode.cpp
+++ b/src/main/GCNode.cpp
@@ -239,9 +239,14 @@ void GCNode::makeMoribund() const
 	// In this case, the node can be deleted immediately.
 	delete this;
     } else {
-	m_rcmms |= s_moribund_mask;
-	s_moribund->push_back(this);
+        addToMoribundList();
     }
+}
+
+void GCNode::addToMoribundList() const
+{
+    m_rcmms |= s_moribund_mask;
+    s_moribund->push_back(this);
 }
 
 void GCNode::mark()


### PR DESCRIPTION
Removes the "on stack" flag test immediately after clearing it.

Also changed clearOnStackBit() to directly add to the moribund list
without testing s_on_stack_bits_correct which is always false when
calling clearOnStackBit().