### PR TITLE
Fix error in runbench.py and update incremental.R

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -4,3 +4,4 @@
 /Rplots.pdf
 /report.pdf
 /tables.pdf
+/commits

--- a/bench/incremental.R
+++ b/bench/incremental.R
@@ -19,8 +19,16 @@
 #  along with this program; if not, a copy is available at
 #  https://www.R-project.org/Licenses/
 
-# Simple script to run nightly and benchmark a small number of commits.  The
-# number of commits to benchmark can be specified as the first command line
+# Simple script to decide which commits to bechmark nightly.  This script only
+# writes the commit hashes for commits to benchmark to an output file. The
+# output needs to be passed to runbench.py.  This script should not not run the
+# runbench.py script because the R environment variables would be inherited by
+# the process and affect benchmark running.
+#
+# Example usage of this script:
+# $ Rscript incremental.R 4 && cat commits | xargs python runbench.py
+#
+# The number of commits to benchmark can be specified as the first command line
 # argument, the default is 3 commits.
 
 num_commit <- 3 # Limits number of commits to be benchmarked.
@@ -40,12 +48,14 @@ if (file.exists('out/versions')) {
 	commits <- read.csv('out/versions', header=F)$V1
 }
 
+out <- c()
 for (rev in revs) {
 	if (num_commit == 0) {
 		break
 	} else if (!(rev %in% commits)) {
-		print(paste('Benchmarking commit', rev))
-		revs <- system2('python', c('runbench.py', rev))
+		print(paste("Selected commit", rev))
+		out <- c(out, rev)
 		num_commit <- num_commit - 1
 	}
 }
+write(file='commits', out)

--- a/bench/runbench.py
+++ b/bench/runbench.py
@@ -54,7 +54,8 @@ benchmarks = [
         { 'name': 'benchmarks/scalar/ForLoopAdd/ForLoopAdd.R', 'warmup_rep': 2, 'bench_rep': 3 },
         { 'name': 'benchmarks/shootout/nbody/nbody.R', 'warmup_rep': 0, 'bench_rep': 1 },
         { 'name': 'benchmarks/shootout/fannkuch-redux/fannkuch-redux.R', 'warmup_rep': 0, 'bench_rep': 1 },
-        { 'name': 'benchmarks/shootout/spectral-norm/spectral-norm.R', 'warmup_rep': 0, 'bench_rep': 1 },
+        # Skip spectral-norm.R because it takes too long for incremental benchmarking.
+        #{ 'name': 'benchmarks/shootout/spectral-norm/spectral-norm.R', 'warmup_rep': 0, 'bench_rep': 1 },
         # Skip mandelbrot.R to avoid duplicate benchmark IDs (conflicts with riposte/mandelbrot.R).
         #{ 'name': 'benchmarks/shootout/mandelbrot/mandelbrot.R', 'warmup_rep': 0, 'bench_rep': 1 },
         { 'name': 'benchmarks/shootout/pidigits/pidigits.R', 'warmup_rep': 0, 'bench_rep': 1 },
@@ -111,6 +112,9 @@ def build_rho(gitref, args, jit, build=True):
         if not os.path.isdir('.git'):
             # Clone Rho into the local directory.
             exit_code = subprocess.call(['git', 'clone', args.repository, '.'])
+        else:
+            # Fetch latest commits.
+            subprocess.call(['git', 'fetch', 'origin'])
         # Clean and switch to the selected revision.
         subprocess.call(['git', 'reset', '--hard', gitref])
         # Build with JIT enabled.
@@ -135,7 +139,7 @@ def get_timestamp(gitref, args):
     bench_dir = os.getcwd()
     try:
         os.chdir(args.build_dir)
-        return subprocess.check_output(['git', 'show', '-s', '--format=%ci', gitref])
+        return subprocess.check_output(['git', 'show', '-s', '--format=%ci', gitref, '--'])
     finally:
         os.chdir(bench_dir)
 


### PR DESCRIPTION
The script runbench.py now fetches commits from the remote repository
before trying to switch revision. This fix makes it possible to
benchmark new commits.

The spectral-norm benchmark has been disabled because it takes too long
to run.

Running benchmarks via incremental.R inherits R environment variables
and affects benchmark results. The script has been changed to instead
write an output file containing the commit hashes to benchmark, the
output can then be passed to runbench.py.