### PR TITLE
More use of R_TrueValue and R_FalseValue.

### DIFF
--- a/src/include/rho/BinaryFunction.hpp
+++ b/src/include/rho/BinaryFunction.hpp
@@ -222,6 +222,9 @@ namespace rho {
 		   the result is zero length. */
 		size = 0;
 	    }
+	    if (size == 1 && !lhs->hasAttributes() && !rhs->hasAttributes()) {
+		return OutputType::createScalar(op((*lhs)[0], (*rhs)[0]));
+	    }
 	    OutputType* result = OutputType::create(size);
 	    if (size == 1) {
 		(*result)[0] = op((*lhs)[0], (*rhs)[0]);

--- a/src/include/rho/FixedVector.hpp
+++ b/src/include/rho/FixedVector.hpp
@@ -111,7 +111,7 @@ namespace rho {
 	 *
 	 * @param value The value to store in the vector.
 	 */
-	template<class U>
+	template<typename U>
 	static FixedVector* createScalar(const U& value) {
 	    FixedVector* result = create(1);
 	    (*result)[0] = value;

--- a/src/include/rho/LogicalVector.hpp
+++ b/src/include/rho/LogicalVector.hpp
@@ -46,6 +46,13 @@ namespace rho {
     struct VectorTypeFor<Logical> {
       typedef LogicalVector type;
     };
+
+    template<>
+    template<typename U>
+    LogicalVector* LogicalVector::createScalar(const U& value) {
+	int value_as_int = static_cast<int>(Logical(value));
+	return static_cast<LogicalVector*>(Rf_ScalarLogical(value_as_int));
+    }
 }  // namespace rho
 
 extern "C" {

--- a/src/include/rho/UnaryFunction.hpp
+++ b/src/include/rho/UnaryFunction.hpp
@@ -121,10 +121,14 @@ namespace rho {
 	template<typename Op, typename AttributeCopier,
 		 typename InputType,
 		 typename OutputType = VectorOpReturnType<Op, InputType>>
-	OutputType* applyUnaryOperator(const Op& op,
+	OutputType* applyUnaryOperator(Op op,
 				       AttributeCopier attribute_copier,
 				       const InputType* input)
 	{
+	    size_t size = input->size();
+	    if (size == 1 && !input->hasAttributes()) {
+		return OutputType::createScalar(op((*input)[0]));
+	    }
 	    OutputType* result = OutputType::create(input->size());
 	    std::transform(input->begin(), input->end(), result->begin(),
 			   op);


### PR DESCRIPTION
In VectorOps, when a unary or binary function returns a scalar logical
value and the operand(s) don't have any attributes, return one of the
pre-allocated scalar logical values (R_TrueValue, R_FalseValue,
R_LogicalNAValue).