### PR TITLE
Replace dynamic_cast by llvm::dyn_cast / llvm::isa

### DIFF
--- a/src/main/jit/Compiler.cpp
+++ b/src/main/jit/Compiler.cpp
@@ -169,7 +169,7 @@ Value* Compiler::emitEval(const RObject* object)
 	// Any subsequent code is dead.  Create a dummy basic block for it.
 	SetInsertPoint(createBasicBlock("dead_code"));
 
-	if (dynamic_cast<llvm::TerminatorInst*>(result)) {
+	if (llvm::isa<llvm::TerminatorInst>(result)) {
 	    // There is no current value either.  Use undef as a placeholder.
 	    return llvm::UndefValue::get(getType<RObject*>());
 	}
@@ -237,7 +237,7 @@ Value* Compiler::emitExpressionEval(const Expression* expression)
 	resolved_function = emitFunctionLookup(symbol, &likely_function);
 	// Check that the lookup succeeded, unless the function was resolved
 	// at compile time.
-	if (!dynamic_cast<llvm::Constant*>(resolved_function)) {
+	if (!llvm::isa<llvm::Constant>(resolved_function)) {
 	    emitErrorUnless(resolved_function,
 			    _("could not find function \"%s\""),
 			    emitConstantPointer(symbol->name()->c_str()));
@@ -378,7 +378,7 @@ Value* Compiler::emitInlineableBuiltinCall(const Expression* expression,
 	return nullptr;
     }
 
-    if (dynamic_cast<llvm::Constant*>(resolved_function)) {
+    if (llvm::isa<llvm::Constant>(resolved_function)) {
 	// When the resolved function is a compile-time constant, everything is
 	// simple.
 	return (this->*emit_builtin)(expression);

--- a/src/main/jit/Optimization.cpp
+++ b/src/main/jit/Optimization.cpp
@@ -58,7 +58,7 @@ bool RemoveRedundantCallsToSetVisibility::runOnBasicBlock(
   // Collect all calls to kSetVisibilityFuncName.
   std::vector<llvm::CallInst*> calls_to_delete;  // Pointed insts not owned.
   for (llvm::Instruction& instr : block) {
-    llvm::CallInst* call_inst = dynamic_cast<llvm::CallInst*>(&instr);
+    llvm::CallInst* call_inst = llvm::dyn_cast<llvm::CallInst>(&instr);
     if (call_inst != nullptr &&
         call_inst->getCalledFunction()->getName() == kSetVisibilityFuncName) {
       calls_to_delete.emplace_back(call_inst);


### PR DESCRIPTION
Replaced uses of dynamic_cast<> by llvm-specific casts and type checks
where possible.