### PR TITLE
Small changes to NAMED handling

### DIFF
--- a/src/main/RObject.cpp
+++ b/src/main/RObject.cpp
@@ -113,8 +113,7 @@ void RObject::copyAttributes(const RObject* source, Duplicate deep)
 
 RObject* RObject::evaluate(Environment* env)
 {
-    if (NAMED(this) != 2)
-	SET_NAMED(this, 2);
+    SET_NAMED(this, 2);
     return this;
 }
 
@@ -276,12 +275,12 @@ void RObject::Transmute(RObject* source,
 			std::function<RObject*(void*)> constructor)
 {
     // Store RObject properties.
-    bool named = source->m_named;
+    unsigned char named = source->m_named;
     bool isS4 = source->isS4Object();
 #ifdef R_MEMORY_PROFILING
     bool memory_traced = source->memoryTraced();
 #endif
-    bool missing = source->m_missing;
+    unsigned missing = source->m_missing;
     bool active_binding = source->m_active_binding;
     bool binding_locked = source->m_binding_locked;
     const PairList* attributes = source->attributes();

--- a/src/main/WeakRef.cpp
+++ b/src/main/WeakRef.cpp
@@ -417,7 +417,6 @@ SEXP R_WeakRefValue(SEXP w)
 	Rf_error(_("not a weak reference"));
     WeakRef* wr = static_cast<WeakRef*>(w);
     SEXP v = wr->value();
-    if (v && NAMED(v) != 2)
-	SET_NAMED(v, 2);
+    SET_NAMED(v, 2);
     return v;
 }

--- a/src/main/coerce.cpp
+++ b/src/main/coerce.cpp
@@ -2454,7 +2454,7 @@ SEXP Rf_substitute(SEXP lang, SEXP rho)
 			t = PREXPR(t);
 		    } while(TYPEOF(t) == PROMSXP);
 		    /* make sure code will not be modified: */
-		    if (NAMED(t) < 2) SET_NAMED(t, 2);
+		    SET_NAMED(t, 2);
 		    return t;
 		}
 		else if (TYPEOF(t) == DOTSXP)
@@ -2564,7 +2564,7 @@ SEXP attribute_hidden do_quote(SEXP call, SEXP op, SEXP args, SEXP rho)
     SEXP val = CAR(args);
     /* Make sure expression has NAMED == 2 before being returning
        in order to avoid modification of source code */
-    if (NAMED(val) != 2) SET_NAMED(val, 2);
+    SET_NAMED(val, 2);
     return(val);
 }
 

--- a/src/main/eval.cpp
+++ b/src/main/eval.cpp
@@ -1329,7 +1329,7 @@ static void SET_TEMPVARLOC_FROM_CAR(Frame::Binding* loc, PairList* lhs) {
    object. */
 #define FIXUP_RHS_NAMED(r) do { \
 	SEXP __rhs__ = (r); \
-	if (NAMED(__rhs__) && NAMED(__rhs__) != 2) \
+	if (NAMED(__rhs__)) \
 	    SET_NAMED(__rhs__, 2); \
     } while (0)
 


### PR DESCRIPTION
* Fixed type errors for two local variable declarations in
RObject::Transmute().

* Removed a few redundant if-statements testing NAMED saturation before
setting the NAMED field to the saturated value.