### PR TITLE
Avoid creating new logicals in parser

### DIFF
--- a/src/library/tools/src/gramLatex.c
+++ b/src/library/tools/src/gramLatex.c
@@ -1,19 +1,19 @@
-/* A Bison parser, made by GNU Bison 2.7.12-4996.  */
+/* A Bison parser, made by GNU Bison 3.0.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
-   
-      Copyright (C) 1984, 1989-1990, 2000-2013 Free Software Foundation, Inc.
-   
+
+   Copyright (C) 1984, 1989-1990, 2000-2013 Free Software Foundation, Inc.
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
@@ -26,7 +26,7 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
@@ -44,7 +44,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "2.7.12-4996"
+#define YYBISON_VERSION "3.0.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -62,7 +62,7 @@
 
 
 /* Copy the first part of user declarations.  */
-
+#line 2 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:339  */
 
 /*
  *  R : A Computer Langage for Statistical Data Analysis
@@ -211,13 +211,13 @@ static int      mkVerbEnv();
 #define YYSTYPE		SEXP
 
 
+#line 215 "y.tab.c" /* yacc.c:339  */
 
-
-# ifndef YY_NULL
+# ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
-#   define YY_NULL nullptr
+#   define YY_NULLPTR nullptr
 #  else
-#   define YY_NULL 0
+#   define YY_NULLPTR 0
 #  endif
 # endif
 
@@ -230,7 +230,7 @@ static int      mkVerbEnv();
 #endif
 
 
-/* Enabling traces.  */
+/* Debug traces.  */
 #ifndef YYDEBUG
 # define YYDEBUG 0
 #endif
@@ -238,21 +238,20 @@ static int      mkVerbEnv();
 extern int yydebug;
 #endif
 
-/* Tokens.  */
+/* Token type.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     END_OF_INPUT = 258,
-     ERROR = 259,
-     MACRO = 260,
-     TEXT = 261,
-     COMMENT = 262,
-     BEGIN = 263,
-     END = 264,
-     VERB = 265
-   };
+  enum yytokentype
+  {
+    END_OF_INPUT = 258,
+    ERROR = 259,
+    MACRO = 260,
+    TEXT = 261,
+    COMMENT = 262,
+    BEGIN = 263,
+    END = 264,
+    VERB = 265
+  };
 #endif
 /* Tokens.  */
 #define END_OF_INPUT 258
@@ -264,49 +263,37 @@ extern int yydebug;
 #define END 264
 #define VERB 265
 
-
-
+/* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 typedef int YYSTYPE;
 # define YYSTYPE_IS_TRIVIAL 1
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
 # define YYSTYPE_IS_DECLARED 1
 #endif
 
+/* Location type.  */
 #if ! defined YYLTYPE && ! defined YYLTYPE_IS_DECLARED
-typedef struct YYLTYPE
+typedef struct YYLTYPE YYLTYPE;
+struct YYLTYPE
 {
   int first_line;
   int first_column;
   int last_line;
   int last_column;
-} YYLTYPE;
-# define yyltype YYLTYPE /* obsolescent; will be withdrawn */
+};
 # define YYLTYPE_IS_DECLARED 1
 # define YYLTYPE_IS_TRIVIAL 1
 #endif
 
+
 extern YYSTYPE yylval;
 extern YYLTYPE yylloc;
-#ifdef YYPARSE_PARAM
-#if defined __STDC__ || defined __cplusplus
-int yyparse (void *YYPARSE_PARAM);
-#else
-int yyparse ();
-#endif
-#else /* ! YYPARSE_PARAM */
-#if defined __STDC__ || defined __cplusplus
 int yyparse (void);
-#else
-int yyparse ();
-#endif
-#endif /* ! YYPARSE_PARAM */
 
 
 
 /* Copy the second part of user declarations.  */
 
-
+#line 297 "y.tab.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -320,11 +307,8 @@ typedef unsigned char yytype_uint8;
 
 #ifdef YYTYPE_INT8
 typedef YYTYPE_INT8 yytype_int8;
-#elif (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-typedef signed char yytype_int8;
 #else
-typedef short int yytype_int8;
+typedef signed char yytype_int8;
 #endif
 
 #ifdef YYTYPE_UINT16
@@ -344,8 +328,7 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+# elif ! defined YYSIZE_T
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
@@ -367,11 +350,30 @@ typedef short int yytype_int16;
 # endif
 #endif
 
-#ifndef __attribute__
-/* This feature is available in gcc versions 2.5 and later.  */
-# if (! defined __GNUC__ || __GNUC__ < 2 \
-      || (__GNUC__ == 2 && __GNUC_MINOR__ < 5))
-#  define __attribute__(Spec) /* empty */
+#ifndef YY_ATTRIBUTE
+# if (defined __GNUC__                                               \
+      && (2 < __GNUC__ || (__GNUC__ == 2 && 96 <= __GNUC_MINOR__)))  \
+     || defined __SUNPRO_C && 0x5110 <= __SUNPRO_C
+#  define YY_ATTRIBUTE(Spec) __attribute__(Spec)
+# else
+#  define YY_ATTRIBUTE(Spec) /* empty */
+# endif
+#endif
+
+#ifndef YY_ATTRIBUTE_PURE
+# define YY_ATTRIBUTE_PURE   YY_ATTRIBUTE ((__pure__))
+#endif
+
+#ifndef YY_ATTRIBUTE_UNUSED
+# define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
+#endif
+
+#if !defined _Noreturn \
+     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
+# if defined _MSC_VER && 1200 <= _MSC_VER
+#  define _Noreturn __declspec (noreturn)
+# else
+#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
 # endif
 #endif
 
@@ -382,24 +384,25 @@ typedef short int yytype_int16;
 # define YYUSE(E) /* empty */
 #endif
 
+#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
+/* Suppress an incorrect diagnostic about yylval being uninitialized.  */
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
+    _Pragma ("GCC diagnostic push") \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")\
+    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END \
+    _Pragma ("GCC diagnostic pop")
+#else
+# define YY_INITIAL_VALUE(Value) Value
+#endif
+#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END
+#endif
+#ifndef YY_INITIAL_VALUE
+# define YY_INITIAL_VALUE(Value) /* Nothing. */
+#endif
 
-/* Identity function, used to suppress warnings about constant conditions.  */
-#ifndef lint
-# define YYID(N) (N)
-#else
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static int
-YYID (int yyi)
-#else
-static int
-YYID (yyi)
-    int yyi;
-#endif
-{
-  return yyi;
-}
-#endif
 
 #if ! defined yyoverflow || YYERROR_VERBOSE
 
@@ -418,8 +421,7 @@ YYID (yyi)
 #    define alloca _alloca
 #   else
 #    define YYSTACK_ALLOC alloca
-#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
 #     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
       /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
 #     ifndef EXIT_SUCCESS
@@ -431,8 +433,8 @@ YYID (yyi)
 # endif
 
 # ifdef YYSTACK_ALLOC
-   /* Pacify GCC's `empty if-body' warning.  */
-#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (YYID (0))
+   /* Pacify GCC's 'empty if-body' warning.  */
+#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (0)
 #  ifndef YYSTACK_ALLOC_MAXIMUM
     /* The OS might guarantee only one guard page at the bottom of the stack,
        and a page size can be as small as 4096 bytes.  So we cannot safely
@@ -448,7 +450,7 @@ YYID (yyi)
 #  endif
 #  if (defined __cplusplus && ! defined EXIT_SUCCESS \
        && ! ((defined YYMALLOC || defined malloc) \
-	     && (defined YYFREE || defined free)))
+             && (defined YYFREE || defined free)))
 #   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
 #   ifndef EXIT_SUCCESS
 #    define EXIT_SUCCESS 0
@@ -456,15 +458,13 @@ YYID (yyi)
 #  endif
 #  ifndef YYMALLOC
 #   define YYMALLOC malloc
-#   if ! defined malloc && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined malloc && ! defined EXIT_SUCCESS
 void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 #  ifndef YYFREE
 #   define YYFREE free
-#   if ! defined free && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined free && ! defined EXIT_SUCCESS
 void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
@@ -474,8 +474,8 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
-	 || (defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL \
-	     && defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
+         || (defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL \
+             && defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
 
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
@@ -501,16 +501,16 @@ union yyalloc
    elements in the stack, and YYPTR gives the new location of the
    stack.  Advance YYPTR to a properly aligned location for the next
    stack.  */
-# define YYSTACK_RELOCATE(Stack_alloc, Stack)				\
-    do									\
-      {									\
-	YYSIZE_T yynewbytes;						\
-	YYCOPY (&yyptr->Stack_alloc, Stack, yysize);			\
-	Stack = &yyptr->Stack_alloc;					\
-	yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-	yyptr += yynewbytes / sizeof (*yyptr);				\
-      }									\
-    while (YYID (0))
+# define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
+    do                                                                  \
+      {                                                                 \
+        YYSIZE_T yynewbytes;                                            \
+        YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
+        Stack = &yyptr->Stack_alloc;                                    \
+        yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / sizeof (*yyptr);                          \
+      }                                                                 \
+    while (0)
 
 #endif
 
@@ -529,7 +529,7 @@ union yyalloc
           for (yyi = 0; yyi < (Count); yyi++)   \
             (Dst)[yyi] = (Src)[yyi];            \
         }                                       \
-      while (YYID (0))
+      while (0)
 #  endif
 # endif
 #endif /* !YYCOPY_NEEDED */
@@ -545,17 +545,19 @@ union yyalloc
 #define YYNNTS  9
 /* YYNRULES -- Number of rules.  */
 #define YYNRULES  21
-/* YYNRULES -- Number of states.  */
+/* YYNSTATES -- Number of states.  */
 #define YYNSTATES  36
 
-/* YYTRANSLATE(YYLEX) -- Bison symbol number corresponding to YYLEX.  */
+/* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
+   by yylex, with out-of-bounds checking.  */
 #define YYUNDEFTOK  2
 #define YYMAXUTOK   265
 
-#define YYTRANSLATE(YYX)						\
+#define YYTRANSLATE(YYX)                                                \
   ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
-/* YYTRANSLATE[YYLEX] -- Bison symbol number corresponding to YYLEX.  */
+/* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, without out-of-bounds checking.  */
 static const yytype_uint8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -588,27 +590,7 @@ static const yytype_uint8 yytranslate[] =
 };
 
 #if YYDEBUG
-/* YYPRHS[YYN] -- Index of the first RHS symbol of rule number YYN in
-   YYRHS.  */
-static const yytype_uint8 yyprhs[] =
-{
-       0,     0,     3,     6,     8,    10,    12,    14,    17,    20,
-      22,    25,    27,    29,    31,    33,    35,    37,    38,    49,
-      53,    57
-};
-
-/* YYRHS -- A `-1'-separated list of the rules' RHS.  */
-static const yytype_int8 yyrhs[] =
-{
-      15,     0,    -1,    16,     3,    -1,     3,    -1,     1,    -1,
-      18,    -1,    21,    -1,    16,    18,    -1,    16,    21,    -1,
-      18,    -1,    17,    18,    -1,     6,    -1,     7,    -1,     5,
-      -1,    10,    -1,    19,    -1,    22,    -1,    -1,     8,    11,
-       6,    12,    20,    16,     9,    11,     6,    12,    -1,    13,
-      17,    13,    -1,    11,    16,    12,    -1,    11,    12,    -1
-};
-
-/* YYRLINE[YYN] -- source line where rule number YYN was defined.  */
+  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
        0,   166,   166,   167,   168,   171,   172,   173,   174,   176,
@@ -625,13 +607,13 @@ static const char *const yytname[] =
   "$end", "error", "$undefined", "END_OF_INPUT", "ERROR", "MACRO", "TEXT",
   "COMMENT", "BEGIN", "END", "VERB", "'{'", "'}'", "'$'", "$accept",
   "Init", "Items", "nonMath", "Item", "environment", "$@1", "math",
-  "block", YY_NULL
+  "block", YY_NULLPTR
 };
 #endif
 
 # ifdef YYPRINT
-/* YYTOKNUM[YYLEX-NUM] -- Internal token number corresponding to
-   token YYLEX-NUM.  */
+/* YYTOKNUM[NUM] -- (External) token number corresponding to the
+   (internal) symbol number NUM (which must be that of a token).  */
 static const yytype_uint16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
@@ -639,42 +621,18 @@ static const yytype_uint16 yytoknum[] =
 };
 # endif
 
-/* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint8 yyr1[] =
-{
-       0,    14,    15,    15,    15,    16,    16,    16,    16,    17,
-      17,    18,    18,    18,    18,    18,    18,    20,    19,    21,
-      22,    22
-};
-
-/* YYR2[YYN] -- Number of symbols composing right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
-{
-       0,     2,     2,     1,     1,     1,     1,     2,     2,     1,
-       2,     1,     1,     1,     1,     1,     1,     0,    10,     3,
-       3,     2
-};
-
-/* YYDEFACT[STATE-NAME] -- Default reduction number in state STATE-NUM.
-   Performed when YYTABLE doesn't specify something else to do.  Zero
-   means the default is an error.  */
-static const yytype_uint8 yydefact[] =
-{
-       0,     4,     3,    13,    11,    12,     0,    14,     0,     0,
-       0,     0,     5,    15,     6,    16,     0,    21,     0,     0,
-       9,     1,     2,     7,     8,     0,    20,    19,    10,    17,
-       0,     0,     0,     0,     0,    18
-};
-
-/* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int8 yydefgoto[] =
-{
-      -1,    10,    11,    19,    12,    13,    30,    14,    15
-};
-
-/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-   STATE-NUM.  */
 #define YYPACT_NINF -10
+
+#define yypact_value_is_default(Yystate) \
+  (!!((Yystate) == (-10)))
+
+#define YYTABLE_NINF -1
+
+#define yytable_value_is_error(Yytable_value) \
+  0
+
+  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+     STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
       23,   -10,   -10,   -10,   -10,   -10,    -8,   -10,    32,    77,
@@ -683,16 +641,32 @@ static const yytype_int8 yypact[] =
       68,    50,    -3,    11,    15,   -10
 };
 
-/* YYPGOTO[NTERM-NUM].  */
+  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+     Performed when YYTABLE does not specify something else to do.  Zero
+     means the default is an error.  */
+static const yytype_uint8 yydefact[] =
+{
+       0,     4,     3,    13,    11,    12,     0,    14,     0,     0,
+       0,     0,     5,    15,     6,    16,     0,    21,     0,     0,
+       9,     1,     2,     7,     8,     0,    20,    19,    10,    17,
+       0,     0,     0,     0,     0,    18
+};
+
+  /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
      -10,   -10,    -7,   -10,    -9,   -10,   -10,    -6,   -10
 };
 
-/* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
-   positive, shift that token.  If negative, reduce the rule which
-   number is the opposite.  If YYTABLE_NINF, syntax error.  */
-#define YYTABLE_NINF -1
+  /* YYDEFGOTO[NTERM-NUM].  */
+static const yytype_int8 yydefgoto[] =
+{
+      -1,    10,    11,    19,    12,    13,    30,    14,    15
+};
+
+  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+     positive, shift that token.  If negative, reduce the rule whose
+     number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_uint8 yytable[] =
 {
       20,    18,    23,    16,    21,    24,    25,    29,    33,    23,
@@ -705,12 +679,6 @@ static const yytype_uint8 yytable[] =
        8,     0,    27,     3,     4,     5,     6,     0,     7,     8,
        0,     9,     3,     4,     5,     6,     0,     7,     8
 };
-
-#define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-10)))
-
-#define yytable_value_is_error(Yytable_value) \
-  YYID (0)
 
 static const yytype_int8 yycheck[] =
 {
@@ -725,8 +693,8 @@ static const yytype_int8 yycheck[] =
       -1,    13,     5,     6,     7,     8,    -1,    10,    11
 };
 
-/* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-   symbol of state STATE-NUM.  */
+  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
+     symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
        0,     1,     3,     5,     6,     7,     8,    10,    11,    13,
@@ -735,30 +703,32 @@ static const yytype_uint8 yystos[] =
       20,    16,     9,    11,     6,    12
 };
 
-#define yyerrok		(yyerrstatus = 0)
-#define yyclearin	(yychar = YYEMPTY)
-#define YYEMPTY		(-2)
-#define YYEOF		0
+  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
+static const yytype_uint8 yyr1[] =
+{
+       0,    14,    15,    15,    15,    16,    16,    16,    16,    17,
+      17,    18,    18,    18,    18,    18,    18,    20,    19,    21,
+      22,    22
+};
 
-#define YYACCEPT	goto yyacceptlab
-#define YYABORT		goto yyabortlab
-#define YYERROR		goto yyerrorlab
+  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
+static const yytype_uint8 yyr2[] =
+{
+       0,     2,     2,     1,     1,     1,     1,     2,     2,     1,
+       2,     1,     1,     1,     1,     1,     1,     0,    10,     3,
+       3,     2
+};
 
 
-/* Like YYERROR except do call yyerror.  This remains here temporarily
-   to ease the transition to the new meaning of YYERROR, for GCC.
-   Once GCC version 2 has supplanted version 1, this can go.  However,
-   YYFAIL appears to be in use.  Nevertheless, it is formally deprecated
-   in Bison 2.4.2's NEWS entry, where a plan to phase it out is
-   discussed.  */
+#define yyerrok         (yyerrstatus = 0)
+#define yyclearin       (yychar = YYEMPTY)
+#define YYEMPTY         (-2)
+#define YYEOF           0
 
-#define YYFAIL		goto yyerrlab
-#if defined YYFAIL
-  /* This is here to suppress warnings from the GCC cpp's
-     -Wunused-macros.  Normally we don't worry about that warning, but
-     some users do, and we want to make it easy for users to remove
-     YYFAIL uses, which will produce warnings from Bison 2.5.  */
-#endif
+#define YYACCEPT        goto yyacceptlab
+#define YYABORT         goto yyabortlab
+#define YYERROR         goto yyerrorlab
+
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
@@ -775,13 +745,13 @@ do                                                              \
   else                                                          \
     {                                                           \
       yyerror (YY_("syntax error: cannot back up")); \
-      YYERROR;							\
-    }								\
-while (YYID (0))
+      YYERROR;                                                  \
+    }                                                           \
+while (0)
 
 /* Error token number */
-#define YYTERROR	1
-#define YYERRCODE	256
+#define YYTERROR        1
+#define YYERRCODE       256
 
 
 /* YYLLOC_DEFAULT -- Set CURRENT to span from RHS[1] to RHS[N].
@@ -791,7 +761,7 @@ while (YYID (0))
 #ifndef YYLLOC_DEFAULT
 # define YYLLOC_DEFAULT(Current, Rhs, N)                                \
     do                                                                  \
-      if (YYID (N))                                                     \
+      if (N)                                                            \
         {                                                               \
           (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;        \
           (Current).first_column = YYRHSLOC (Rhs, 1).first_column;      \
@@ -805,10 +775,25 @@ while (YYID (0))
           (Current).first_column = (Current).last_column =              \
             YYRHSLOC (Rhs, 0).last_column;                              \
         }                                                               \
-    while (YYID (0))
+    while (0)
 #endif
 
 #define YYRHSLOC(Rhs, K) ((Rhs)[K])
+
+
+/* Enable debugging if requested.  */
+#if YYDEBUG
+
+# ifndef YYFPRINTF
+#  include <stdio.h> /* INFRINGES ON USER NAME SPACE */
+#  define YYFPRINTF fprintf
+# endif
+
+# define YYDPRINTF(Args)                        \
+do {                                            \
+  if (yydebug)                                  \
+    YYFPRINTF Args;                             \
+} while (0)
 
 
 /* YY_LOCATION_PRINT -- Print the location on the stream.
@@ -820,36 +805,28 @@ while (YYID (0))
 
 /* Print *YYLOCP on YYO.  Private, do not rely on its existence. */
 
-__attribute__((__unused__))
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+YY_ATTRIBUTE_UNUSED
 static unsigned
 yy_location_print_ (FILE *yyo, YYLTYPE const * const yylocp)
-#else
-static unsigned
-yy_location_print_ (yyo, yylocp)
-    FILE *yyo;
-    YYLTYPE const * const yylocp;
-#endif
 {
   unsigned res = 0;
   int end_col = 0 != yylocp->last_column ? yylocp->last_column - 1 : 0;
   if (0 <= yylocp->first_line)
     {
-      res += fprintf (yyo, "%d", yylocp->first_line);
+      res += YYFPRINTF (yyo, "%d", yylocp->first_line);
       if (0 <= yylocp->first_column)
-        res += fprintf (yyo, ".%d", yylocp->first_column);
+        res += YYFPRINTF (yyo, ".%d", yylocp->first_column);
     }
   if (0 <= yylocp->last_line)
     {
       if (yylocp->first_line < yylocp->last_line)
         {
-          res += fprintf (yyo, "-%d", yylocp->last_line);
+          res += YYFPRINTF (yyo, "-%d", yylocp->last_line);
           if (0 <= end_col)
-            res += fprintf (yyo, ".%d", end_col);
+            res += YYFPRINTF (yyo, ".%d", end_col);
         }
       else if (0 <= end_col && yylocp->first_column < end_col)
-        res += fprintf (yyo, "-%d", end_col);
+        res += YYFPRINTF (yyo, "-%d", end_col);
     }
   return res;
  }
@@ -863,67 +840,33 @@ yy_location_print_ (yyo, yylocp)
 #endif
 
 
-/* YYLEX -- calling `yylex' with the right arguments.  */
-#ifdef YYLEX_PARAM
-# define YYLEX yylex (YYLEX_PARAM)
-#else
-# define YYLEX yylex ()
-#endif
-
-/* Enable debugging if requested.  */
-#if YYDEBUG
-
-# ifndef YYFPRINTF
-#  include <stdio.h> /* INFRINGES ON USER NAME SPACE */
-#  define YYFPRINTF fprintf
-# endif
-
-# define YYDPRINTF(Args)			\
-do {						\
-  if (yydebug)					\
-    YYFPRINTF Args;				\
-} while (YYID (0))
-
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)			  \
-do {									  \
-  if (yydebug)								  \
-    {									  \
-      YYFPRINTF (stderr, "%s ", Title);					  \
-      yy_symbol_print (stderr,						  \
-		  Type, Value, Location); \
-      YYFPRINTF (stderr, "\n");						  \
-    }									  \
-} while (YYID (0))
+# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
+do {                                                                      \
+  if (yydebug)                                                            \
+    {                                                                     \
+      YYFPRINTF (stderr, "%s ", Title);                                   \
+      yy_symbol_print (stderr,                                            \
+                  Type, Value, Location); \
+      YYFPRINTF (stderr, "\n");                                           \
+    }                                                                     \
+} while (0)
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*----------------------------------------.
+| Print this symbol's value on YYOUTPUT.  |
+`----------------------------------------*/
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
 yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
-#else
-static void
-yy_symbol_value_print (yyoutput, yytype, yyvaluep, yylocationp)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-    YYLTYPE const * const yylocationp;
-#endif
 {
   FILE *yyo = yyoutput;
   YYUSE (yyo);
+  YYUSE (yylocationp);
   if (!yyvaluep)
     return;
-  YYUSE (yylocationp);
 # ifdef YYPRINT
   if (yytype < YYNTOKENS)
     YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
-# else
-  YYUSE (yyoutput);
 # endif
   YYUSE (yytype);
 }
@@ -933,23 +876,11 @@ yy_symbol_value_print (yyoutput, yytype, yyvaluep, yylocationp)
 | Print this symbol on YYOUTPUT.  |
 `--------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
 yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
-#else
-static void
-yy_symbol_print (yyoutput, yytype, yyvaluep, yylocationp)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-    YYLTYPE const * const yylocationp;
-#endif
 {
-  if (yytype < YYNTOKENS)
-    YYFPRINTF (yyoutput, "token %s (", yytname[yytype]);
-  else
-    YYFPRINTF (yyoutput, "nterm %s (", yytname[yytype]);
+  YYFPRINTF (yyoutput, "%s %s (",
+             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
   YY_LOCATION_PRINT (yyoutput, *yylocationp);
   YYFPRINTF (yyoutput, ": ");
@@ -962,16 +893,8 @@ yy_symbol_print (yyoutput, yytype, yyvaluep, yylocationp)
 | TOP (included).                                                   |
 `------------------------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
 yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
-#else
-static void
-yy_stack_print (yybottom, yytop)
-    yytype_int16 *yybottom;
-    yytype_int16 *yytop;
-#endif
 {
   YYFPRINTF (stderr, "Stack now");
   for (; yybottom <= yytop; yybottom++)
@@ -982,50 +905,42 @@ yy_stack_print (yybottom, yytop)
   YYFPRINTF (stderr, "\n");
 }
 
-# define YY_STACK_PRINT(Bottom, Top)				\
-do {								\
-  if (yydebug)							\
-    yy_stack_print ((Bottom), (Top));				\
-} while (YYID (0))
+# define YY_STACK_PRINT(Bottom, Top)                            \
+do {                                                            \
+  if (yydebug)                                                  \
+    yy_stack_print ((Bottom), (Top));                           \
+} while (0)
 
 
 /*------------------------------------------------.
 | Report that the YYRULE is going to be reduced.  |
 `------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_reduce_print (YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule)
-#else
-static void
-yy_reduce_print (yyvsp, yylsp, yyrule)
-    YYSTYPE *yyvsp;
-    YYLTYPE *yylsp;
-    int yyrule;
-#endif
+yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule)
 {
+  unsigned long int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  unsigned long int yylno = yyrline[yyrule];
   YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
-	     yyrule - 1, yylno);
+             yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
-      yy_symbol_print (stderr, yyrhs[yyprhs[yyrule] + yyi],
-		       &(yyvsp[(yyi + 1) - (yynrhs)])
-		       , &(yylsp[(yyi + 1) - (yynrhs)])		       );
+      yy_symbol_print (stderr,
+                       yystos[yyssp[yyi + 1 - yynrhs]],
+                       &(yyvsp[(yyi + 1) - (yynrhs)])
+                       , &(yylsp[(yyi + 1) - (yynrhs)])                       );
       YYFPRINTF (stderr, "\n");
     }
 }
 
-# define YY_REDUCE_PRINT(Rule)		\
-do {					\
-  if (yydebug)				\
-    yy_reduce_print (yyvsp, yylsp, Rule); \
-} while (YYID (0))
+# define YY_REDUCE_PRINT(Rule)          \
+do {                                    \
+  if (yydebug)                          \
+    yy_reduce_print (yyssp, yyvsp, yylsp, Rule); \
+} while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
    multiple parsers can coexist.  */
@@ -1039,7 +954,7 @@ int yydebug;
 
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
-#ifndef	YYINITDEPTH
+#ifndef YYINITDEPTH
 # define YYINITDEPTH 200
 #endif
 
@@ -1062,15 +977,8 @@ int yydebug;
 #   define yystrlen strlen
 #  else
 /* Return the length of YYSTR.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static YYSIZE_T
 yystrlen (const char *yystr)
-#else
-static YYSIZE_T
-yystrlen (yystr)
-    const char *yystr;
-#endif
 {
   YYSIZE_T yylen;
   for (yylen = 0; yystr[yylen]; yylen++)
@@ -1086,16 +994,8 @@ yystrlen (yystr)
 #  else
 /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
    YYDEST.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static char *
 yystpcpy (char *yydest, const char *yysrc)
-#else
-static char *
-yystpcpy (yydest, yysrc)
-    char *yydest;
-    const char *yysrc;
-#endif
 {
   char *yyd = yydest;
   const char *yys = yysrc;
@@ -1125,27 +1025,27 @@ yytnamerr (char *yyres, const char *yystr)
       char const *yyp = yystr;
 
       for (;;)
-	switch (*++yyp)
-	  {
-	  case '\'':
-	  case ',':
-	    goto do_not_strip_quotes;
+        switch (*++yyp)
+          {
+          case '\'':
+          case ',':
+            goto do_not_strip_quotes;
 
-	  case '\\':
-	    if (*++yyp != '\\')
-	      goto do_not_strip_quotes;
-	    /* Fall through.  */
-	  default:
-	    if (yyres)
-	      yyres[yyn] = *yyp;
-	    yyn++;
-	    break;
+          case '\\':
+            if (*++yyp != '\\')
+              goto do_not_strip_quotes;
+            /* Fall through.  */
+          default:
+            if (yyres)
+              yyres[yyn] = *yyp;
+            yyn++;
+            break;
 
-	  case '"':
-	    if (yyres)
-	      yyres[yyn] = '\0';
-	    return yyn;
-	  }
+          case '"':
+            if (yyres)
+              yyres[yyn] = '\0';
+            return yyn;
+          }
     do_not_strip_quotes: ;
     }
 
@@ -1168,11 +1068,11 @@ static int
 yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
                 yytype_int16 *yyssp, int yytoken)
 {
-  YYSIZE_T yysize0 = yytnamerr (YY_NULL, yytname[yytoken]);
+  YYSIZE_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
   YYSIZE_T yysize = yysize0;
   enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
   /* Internationalized format string. */
-  const char *yyformat = YY_NULL;
+  const char *yyformat = YY_NULLPTR;
   /* Arguments of yyformat. */
   char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
   /* Number of reported tokens (one for the "unexpected", one per
@@ -1180,10 +1080,6 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
   int yycount = 0;
 
   /* There are many possibilities here to consider:
-     - Assume YYFAIL is not used.  It's too flawed to consider.  See
-       <http://lists.gnu.org/archive/html/bison-patches/2009-12/msg00024.html>
-       for details.  YYERROR is fine as it does not invoke this
-       function.
      - If this state is a consistent state with a default action, then
        the only way this function was invoked is if the default action
        is an error action.  In that case, don't check for expected
@@ -1233,7 +1129,7 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
                   }
                 yyarg[yycount++] = yytname[yyx];
                 {
-                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULL, yytname[yyx]);
+                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
                   if (! (yysize <= yysize1
                          && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
                     return 2;
@@ -1300,58 +1196,53 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
 yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp)
-#else
-static void
-yydestruct (yymsg, yytype, yyvaluep, yylocationp)
-    const char *yymsg;
-    int yytype;
-    YYSTYPE *yyvaluep;
-    YYLTYPE *yylocationp;
-#endif
 {
   YYUSE (yyvaluep);
   YYUSE (yylocationp);
-
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
 
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   switch (yytype)
     {
-      case 5: /* MACRO */
-
-        { UNPROTECT_PTR((*yyvaluep)); };
-
+          case 5: /* MACRO  */
+#line 162 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1257  */
+      { UNPROTECT_PTR(((*yyvaluep))); }
+#line 1215 "y.tab.c" /* yacc.c:1257  */
         break;
-      case 6: /* TEXT */
 
-        { UNPROTECT_PTR((*yyvaluep)); };
-
+    case 6: /* TEXT  */
+#line 162 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1257  */
+      { UNPROTECT_PTR(((*yyvaluep))); }
+#line 1221 "y.tab.c" /* yacc.c:1257  */
         break;
-      case 7: /* COMMENT */
 
-        { UNPROTECT_PTR((*yyvaluep)); };
-
+    case 7: /* COMMENT  */
+#line 162 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1257  */
+      { UNPROTECT_PTR(((*yyvaluep))); }
+#line 1227 "y.tab.c" /* yacc.c:1257  */
         break;
-      case 8: /* BEGIN */
 
-        { UNPROTECT_PTR((*yyvaluep)); };
-
+    case 8: /* BEGIN  */
+#line 162 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1257  */
+      { UNPROTECT_PTR(((*yyvaluep))); }
+#line 1233 "y.tab.c" /* yacc.c:1257  */
         break;
-      case 9: /* END */
 
-        { UNPROTECT_PTR((*yyvaluep)); };
-
+    case 9: /* END  */
+#line 162 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1257  */
+      { UNPROTECT_PTR(((*yyvaluep))); }
+#line 1239 "y.tab.c" /* yacc.c:1257  */
         break;
+
 
       default:
         break;
     }
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
@@ -1360,26 +1251,14 @@ yydestruct (yymsg, yytype, yyvaluep, yylocationp)
 /* The lookahead symbol.  */
 int yychar;
 
-
-#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-# define YY_IGNORE_MAYBE_UNINITIALIZED_END
-#endif
-#ifndef YY_INITIAL_VALUE
-# define YY_INITIAL_VALUE(Value) /* Nothing. */
-#endif
-
 /* The semantic value of the lookahead symbol.  */
-YYSTYPE yylval YY_INITIAL_VALUE(yyval_default);
-
+YYSTYPE yylval;
 /* Location data for the lookahead symbol.  */
 YYLTYPE yylloc
 # if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
   = { 1, 1, 1, 1 }
 # endif
 ;
-
-
 /* Number of syntax errors so far.  */
 int yynerrs;
 
@@ -1388,36 +1267,17 @@ int yynerrs;
 | yyparse.  |
 `----------*/
 
-#ifdef YYPARSE_PARAM
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-int
-yyparse (void *YYPARSE_PARAM)
-#else
-int
-yyparse (YYPARSE_PARAM)
-    void *YYPARSE_PARAM;
-#endif
-#else /* ! YYPARSE_PARAM */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 int
 yyparse (void)
-#else
-int
-yyparse ()
-
-#endif
-#endif
 {
     int yystate;
     /* Number of tokens to shift before error messages enabled.  */
     int yyerrstatus;
 
     /* The stacks and their tools:
-       `yyss': related to states.
-       `yyvs': related to semantic values.
-       `yyls': related to locations.
+       'yyss': related to states.
+       'yyvs': related to semantic values.
+       'yyls': related to locations.
 
        Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
@@ -1496,26 +1356,26 @@ yyparse ()
 
 #ifdef yyoverflow
       {
-	/* Give user a chance to reallocate the stack.  Use copies of
-	   these so that the &'s don't force the real ones into
-	   memory.  */
-	YYSTYPE *yyvs1 = yyvs;
-	yytype_int16 *yyss1 = yyss;
-	YYLTYPE *yyls1 = yyls;
+        /* Give user a chance to reallocate the stack.  Use copies of
+           these so that the &'s don't force the real ones into
+           memory.  */
+        YYSTYPE *yyvs1 = yyvs;
+        yytype_int16 *yyss1 = yyss;
+        YYLTYPE *yyls1 = yyls;
 
-	/* Each stack pointer address is followed by the size of the
-	   data in use in that stack, in bytes.  This used to be a
-	   conditional around just the two extra args, but that might
-	   be undefined if yyoverflow is a macro.  */
-	yyoverflow (YY_("memory exhausted"),
-		    &yyss1, yysize * sizeof (*yyssp),
-		    &yyvs1, yysize * sizeof (*yyvsp),
-		    &yyls1, yysize * sizeof (*yylsp),
-		    &yystacksize);
+        /* Each stack pointer address is followed by the size of the
+           data in use in that stack, in bytes.  This used to be a
+           conditional around just the two extra args, but that might
+           be undefined if yyoverflow is a macro.  */
+        yyoverflow (YY_("memory exhausted"),
+                    &yyss1, yysize * sizeof (*yyssp),
+                    &yyvs1, yysize * sizeof (*yyvsp),
+                    &yyls1, yysize * sizeof (*yylsp),
+                    &yystacksize);
 
-	yyls = yyls1;
-	yyss = yyss1;
-	yyvs = yyvs1;
+        yyls = yyls1;
+        yyss = yyss1;
+        yyvs = yyvs1;
       }
 #else /* no yyoverflow */
 # ifndef YYSTACK_RELOCATE
@@ -1523,23 +1383,23 @@ yyparse ()
 # else
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-	goto yyexhaustedlab;
+        goto yyexhaustedlab;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
-	yystacksize = YYMAXDEPTH;
+        yystacksize = YYMAXDEPTH;
 
       {
-	yytype_int16 *yyss1 = yyss;
-	union yyalloc *yyptr =
-	  (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
-	if (! yyptr)
-	  goto yyexhaustedlab;
-	YYSTACK_RELOCATE (yyss_alloc, yyss);
-	YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-	YYSTACK_RELOCATE (yyls_alloc, yyls);
+        yytype_int16 *yyss1 = yyss;
+        union yyalloc *yyptr =
+          (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
+        if (! yyptr)
+          goto yyexhaustedlab;
+        YYSTACK_RELOCATE (yyss_alloc, yyss);
+        YYSTACK_RELOCATE (yyvs_alloc, yyvs);
+        YYSTACK_RELOCATE (yyls_alloc, yyls);
 #  undef YYSTACK_RELOCATE
-	if (yyss1 != yyssa)
-	  YYSTACK_FREE (yyss1);
+        if (yyss1 != yyssa)
+          YYSTACK_FREE (yyss1);
       }
 # endif
 #endif /* no yyoverflow */
@@ -1549,10 +1409,10 @@ yyparse ()
       yylsp = yyls + yysize - 1;
 
       YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-		  (unsigned long int) yystacksize));
+                  (unsigned long int) yystacksize));
 
       if (yyss + yystacksize - 1 <= yyssp)
-	YYABORT;
+        YYABORT;
     }
 
   YYDPRINTF ((stderr, "Entering state %d\n", yystate));
@@ -1581,7 +1441,7 @@ yybackup:
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token: "));
-      yychar = YYLEX;
+      yychar = yylex ();
     }
 
   if (yychar <= YYEOF)
@@ -1646,7 +1506,7 @@ yyreduce:
   yylen = yyr2[yyn];
 
   /* If YYLEN is nonzero, implement the default value of the action:
-     `$$ = $1'.
+     '$$ = $1'.
 
      Otherwise, the following line sets YYVAL to garbage.
      This behavior is undocumented and Bison
@@ -1661,108 +1521,128 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-
-    { xxsavevalue((yyvsp[(1) - (2)]), &(yyloc)); YYACCEPT; }
+#line 166 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { xxsavevalue((yyvsp[-1]), &(yyloc)); YYACCEPT; }
+#line 1527 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 3:
-
+#line 167 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
     { xxsavevalue(NULL, &(yyloc)); YYACCEPT; }
+#line 1533 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 4:
-
+#line 168 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
     { PROTECT(parseState.Value = R_NilValue);  YYABORT; }
+#line 1539 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 5:
-
-    { (yyval) = xxnewlist((yyvsp[(1) - (1)])); }
+#line 171 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { (yyval) = xxnewlist((yyvsp[0])); }
+#line 1545 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 6:
-
-    { (yyval) = xxnewlist((yyvsp[(1) - (1)])); }
+#line 172 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { (yyval) = xxnewlist((yyvsp[0])); }
+#line 1551 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 7:
-
-    { (yyval) = xxlist((yyvsp[(1) - (2)]), (yyvsp[(2) - (2)])); }
+#line 173 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { (yyval) = xxlist((yyvsp[-1]), (yyvsp[0])); }
+#line 1557 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 8:
-
-    { (yyval) = xxlist((yyvsp[(1) - (2)]), (yyvsp[(2) - (2)])); }
+#line 174 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { (yyval) = xxlist((yyvsp[-1]), (yyvsp[0])); }
+#line 1563 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 9:
-
-    { (yyval) = xxnewlist((yyvsp[(1) - (1)])); }
+#line 176 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { (yyval) = xxnewlist((yyvsp[0])); }
+#line 1569 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 10:
-
-    { (yyval) = xxlist((yyvsp[(1) - (2)]), (yyvsp[(2) - (2)])); }
+#line 177 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { (yyval) = xxlist((yyvsp[-1]), (yyvsp[0])); }
+#line 1575 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 11:
-
-    { (yyval) = xxtag((yyvsp[(1) - (1)]), TEXT, &(yyloc)); }
+#line 179 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { (yyval) = xxtag((yyvsp[0]), TEXT, &(yyloc)); }
+#line 1581 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 12:
-
-    { (yyval) = xxtag((yyvsp[(1) - (1)]), COMMENT, &(yyloc)); }
+#line 180 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { (yyval) = xxtag((yyvsp[0]), COMMENT, &(yyloc)); }
+#line 1587 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 13:
-
-    { (yyval) = xxtag((yyvsp[(1) - (1)]), MACRO, &(yyloc)); }
+#line 181 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { (yyval) = xxtag((yyvsp[0]), MACRO, &(yyloc)); }
+#line 1593 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 14:
-
-    { (yyval) = xxtag((yyvsp[(1) - (1)]), VERB, &(yyloc)); }
+#line 182 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { (yyval) = xxtag((yyvsp[0]), VERB, &(yyloc)); }
+#line 1599 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 15:
-
-    { (yyval) = (yyvsp[(1) - (1)]); }
+#line 183 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[0]); }
+#line 1605 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 16:
-
-    { (yyval) = (yyvsp[(1) - (1)]); }
+#line 184 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[0]); }
+#line 1611 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 17:
-
-    { xxSetInVerbEnv((yyvsp[(3) - (4)])); }
+#line 186 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { xxSetInVerbEnv((yyvsp[-1])); }
+#line 1617 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 18:
-
-    { (yyval) = xxenv((yyvsp[(3) - (10)]), (yyvsp[(6) - (10)]), (yyvsp[(9) - (10)]), &(yyloc));
-                                                  UNPROTECT_PTR((yyvsp[(1) - (10)])); UNPROTECT_PTR((yyvsp[(7) - (10)])); }
+#line 187 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { (yyval) = xxenv((yyvsp[-7]), (yyvsp[-4]), (yyvsp[-1]), &(yyloc));
+                                                  UNPROTECT_PTR((yyvsp[-9])); UNPROTECT_PTR((yyvsp[-3])); }
+#line 1624 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 19:
-
-    { (yyval) = xxmath((yyvsp[(2) - (3)]), &(yyloc)); }
+#line 190 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { (yyval) = xxmath((yyvsp[-1]), &(yyloc)); }
+#line 1630 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 20:
-
-    { (yyval) = xxblock((yyvsp[(2) - (3)]), &(yyloc)); }
+#line 192 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
+    { (yyval) = xxblock((yyvsp[-1]), &(yyloc)); }
+#line 1636 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 21:
-
+#line 193 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1646  */
     { (yyval) = xxblock(NULL, &(yyloc)); }
+#line 1642 "y.tab.c" /* yacc.c:1646  */
     break;
 
 
-
+#line 1646 "y.tab.c" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1785,7 +1665,7 @@ yyreduce:
   *++yyvsp = yyval;
   *++yylsp = yyloc;
 
-  /* Now `shift' the result of the reduction.  Determine what state
+  /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
 
@@ -1800,9 +1680,9 @@ yyreduce:
   goto yynewstate;
 
 
-/*------------------------------------.
-| yyerrlab -- here on detecting error |
-`------------------------------------*/
+/*--------------------------------------.
+| yyerrlab -- here on detecting error.  |
+`--------------------------------------*/
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
@@ -1853,20 +1733,20 @@ yyerrlab:
   if (yyerrstatus == 3)
     {
       /* If just tried and failed to reuse lookahead token after an
-	 error, discard it.  */
+         error, discard it.  */
 
       if (yychar <= YYEOF)
-	{
-	  /* Return failure if at end of input.  */
-	  if (yychar == YYEOF)
-	    YYABORT;
-	}
+        {
+          /* Return failure if at end of input.  */
+          if (yychar == YYEOF)
+            YYABORT;
+        }
       else
-	{
-	  yydestruct ("Error: discarding",
-		      yytoken, &yylval, &yylloc);
-	  yychar = YYEMPTY;
-	}
+        {
+          yydestruct ("Error: discarding",
+                      yytoken, &yylval, &yylloc);
+          yychar = YYEMPTY;
+        }
     }
 
   /* Else will try to reuse lookahead token after shifting the error
@@ -1886,7 +1766,7 @@ yyerrorlab:
      goto yyerrorlab;
 
   yyerror_range[1] = yylsp[1-yylen];
-  /* Do not reclaim the symbols of the rule which action triggered
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
   YYPOPSTACK (yylen);
   yylen = 0;
@@ -1899,29 +1779,29 @@ yyerrorlab:
 | yyerrlab1 -- common code for both syntax error and YYERROR.  |
 `-------------------------------------------------------------*/
 yyerrlab1:
-  yyerrstatus = 3;	/* Each real token shifted decrements this.  */
+  yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
   for (;;)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
-	{
-	  yyn += YYTERROR;
-	  if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
-	    {
-	      yyn = yytable[yyn];
-	      if (0 < yyn)
-		break;
-	    }
-	}
+        {
+          yyn += YYTERROR;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+            {
+              yyn = yytable[yyn];
+              if (0 < yyn)
+                break;
+            }
+        }
 
       /* Pop the current state because it cannot handle the error token.  */
       if (yyssp == yyss)
-	YYABORT;
+        YYABORT;
 
       yyerror_range[1] = *yylsp;
       yydestruct ("Error: popping",
-		  yystos[yystate], yyvsp, yylsp);
+                  yystos[yystate], yyvsp, yylsp);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -1977,14 +1857,14 @@ yyreturn:
       yydestruct ("Cleanup: discarding lookahead",
                   yytoken, &yylval, &yylloc);
     }
-  /* Do not reclaim the symbols of the rule which action triggered
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
   YYPOPSTACK (yylen);
   YY_STACK_PRINT (yyss, yyssp);
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-		  yystos[*yyssp], yyvsp, yylsp);
+                  yystos[*yyssp], yyvsp, yylsp);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
@@ -1995,12 +1875,9 @@ yyreturn:
   if (yymsg != yymsgbuf)
     YYSTACK_FREE (yymsg);
 #endif
-  /* Make sure YYID is used.  */
-  return YYID (yyresult);
+  return yyresult;
 }
-
-
-
+#line 195 "../../../../../src/library/tools/src/gramLatex.y" /* yacc.c:1906  */
 
 
 static SEXP xxnewlist(SEXP item)

--- a/src/main/gram.cpp
+++ b/src/main/gram.cpp
@@ -71,7 +71,7 @@
 #define yylloc          gram_lloc
 
 /* Copy the first part of user declarations.  */
-#line 1 "../../../rho/src/main/gram.y" /* yacc.c:339  */
+#line 1 "../../../src/main/gram.y" /* yacc.c:339  */
 
 /*
  *  R : A Computer Langage for Statistical Data Analysis
@@ -1956,535 +1956,535 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 354 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 354 "../../../src/main/gram.y" /* yacc.c:1646  */
     { YYACCEPT; }
 #line 1962 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 3:
-#line 355 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 355 "../../../src/main/gram.y" /* yacc.c:1646  */
     { yyresult = xxvalue(NULL,2,NULL);	goto yyreturn; }
 #line 1968 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 356 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 356 "../../../src/main/gram.y" /* yacc.c:1646  */
     { yyresult = xxvalue((yyvsp[-1]),3,&(yylsp[-1]));	goto yyreturn; }
 #line 1974 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 5:
-#line 357 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 357 "../../../src/main/gram.y" /* yacc.c:1646  */
     { yyresult = xxvalue((yyvsp[-1]),4,&(yylsp[-1]));	goto yyreturn; }
 #line 1980 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 358 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 358 "../../../src/main/gram.y" /* yacc.c:1646  */
     { YYABORT; }
 #line 1986 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 361 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 361 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = (yyvsp[0]); }
 #line 1992 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 8:
-#line 362 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 362 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = (yyvsp[0]); }
 #line 1998 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 365 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 365 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0])); }
 #line 2004 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 368 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 368 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = (yyvsp[0]);	setId( (yyval), (yyloc)); }
 #line 2010 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 369 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 369 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = (yyvsp[0]);	setId( (yyval), (yyloc)); }
 #line 2016 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 370 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 370 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = (yyvsp[0]);	setId( (yyval), (yyloc)); }
 #line 2022 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 13:
-#line 371 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 371 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = (yyvsp[0]);	setId( (yyval), (yyloc)); }
 #line 2028 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 14:
-#line 373 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 373 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxexprlist((yyvsp[-2]),&(yylsp[-2]),(yyvsp[-1])); setId( (yyval), (yyloc)); }
 #line 2034 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 15:
-#line 374 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 374 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxparen((yyvsp[-2]),(yyvsp[-1]));	setId( (yyval), (yyloc)); }
 #line 2040 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 16:
-#line 376 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 376 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxunary((yyvsp[-1]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2046 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 17:
-#line 377 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 377 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxunary((yyvsp[-1]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2052 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 378 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 378 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxunary((yyvsp[-1]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2058 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 19:
-#line 379 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 379 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxunary((yyvsp[-1]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2064 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 20:
-#line 380 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 380 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxunary((yyvsp[-1]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2070 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 21:
-#line 382 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 382 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2076 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 22:
-#line 383 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 383 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2082 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 23:
-#line 384 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 384 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2088 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 24:
-#line 385 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 385 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2094 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 25:
-#line 386 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 386 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2100 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 26:
-#line 387 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 387 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2106 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 27:
-#line 388 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 388 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2112 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 28:
-#line 389 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 389 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2118 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 29:
-#line 390 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 390 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2124 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 30:
-#line 391 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 391 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2130 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 31:
-#line 392 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 392 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2136 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 32:
-#line 393 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 393 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2142 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 33:
-#line 394 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 394 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2148 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 34:
-#line 395 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 395 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2154 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 35:
-#line 396 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 396 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2160 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 36:
-#line 397 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 397 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2166 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 37:
-#line 398 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 398 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2172 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 38:
-#line 399 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 399 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2178 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 39:
-#line 400 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 400 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2184 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 40:
-#line 401 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 401 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2190 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 41:
-#line 403 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 403 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2196 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 42:
-#line 404 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 404 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[0]),(yyvsp[-2]));	setId( (yyval), (yyloc)); }
 #line 2202 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 43:
-#line 406 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 406 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxdefun((yyvsp[-5]),(yyvsp[-3]),(yyvsp[0]),&(yyloc)); 	setId( (yyval), (yyloc)); }
 #line 2208 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 44:
-#line 407 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 407 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxfuncall((yyvsp[-3]),(yyvsp[-1]));  setId( (yyval), (yyloc)); modif_token( &(yylsp[-3]), SYMBOL_FUNCTION_CALL ) ; }
 #line 2214 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 45:
-#line 408 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 408 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxif((yyvsp[-2]),(yyvsp[-1]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2220 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 46:
-#line 409 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 409 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxifelse((yyvsp[-4]),(yyvsp[-3]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2226 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 47:
-#line 410 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 410 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxfor((yyvsp[-2]),(yyvsp[-1]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2232 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 48:
-#line 411 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 411 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxwhile((yyvsp[-2]),(yyvsp[-1]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2238 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 49:
-#line 412 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 412 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxrepeat((yyvsp[-1]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2244 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 50:
-#line 413 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 413 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxsubscript((yyvsp[-4]),(yyvsp[-3]),(yyvsp[-2]));	setId( (yyval), (yyloc)); }
 #line 2250 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 51:
-#line 414 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 414 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxsubscript((yyvsp[-3]),(yyvsp[-2]),(yyvsp[-1]));	setId( (yyval), (yyloc)); }
 #line 2256 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 52:
-#line 415 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 415 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));      setId( (yyval), (yyloc)); modif_token( &(yylsp[-2]), SYMBOL_PACKAGE ) ; }
 #line 2262 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 53:
-#line 416 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 416 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));      setId( (yyval), (yyloc)); modif_token( &(yylsp[-2]), SYMBOL_PACKAGE ) ; }
 #line 2268 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 54:
-#line 417 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 417 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2274 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 55:
-#line 418 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 418 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2280 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 56:
-#line 419 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 419 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));      setId( (yyval), (yyloc)); modif_token( &(yylsp[-2]), SYMBOL_PACKAGE ) ;}
 #line 2286 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 57:
-#line 420 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 420 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));      setId( (yyval), (yyloc)); modif_token( &(yylsp[-2]), SYMBOL_PACKAGE ) ;}
 #line 2292 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 58:
-#line 421 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 421 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2298 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 59:
-#line 422 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 422 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2304 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 60:
-#line 423 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 423 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2310 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 61:
-#line 424 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 424 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2316 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 62:
-#line 425 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 425 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));      setId( (yyval), (yyloc)); modif_token( &(yylsp[0]), SLOT ) ; }
 #line 2322 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 63:
-#line 426 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 426 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxbinary((yyvsp[-1]),(yyvsp[-2]),(yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2328 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 64:
-#line 427 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 427 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxnxtbrk((yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2334 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 65:
-#line 428 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 428 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxnxtbrk((yyvsp[0]));	setId( (yyval), (yyloc)); }
 #line 2340 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 66:
-#line 432 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 432 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxcond((yyvsp[-1]));   }
 #line 2346 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 67:
-#line 435 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 435 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxifcond((yyvsp[-1])); }
 #line 2352 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 68:
-#line 438 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 438 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxforcond((yyvsp[-3]),(yyvsp[-1]));	setId( (yyval), (yyloc)); }
 #line 2358 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 69:
-#line 442 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 442 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxexprlist0();	setId( (yyval), (yyloc)); }
 #line 2364 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 70:
-#line 443 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 443 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxexprlist1((yyvsp[0]), &(yylsp[0])); }
 #line 2370 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 71:
-#line 444 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 444 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxexprlist2((yyvsp[-2]), (yyvsp[0]), &(yylsp[0])); }
 #line 2376 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 72:
-#line 445 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 445 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = (yyvsp[-1]);		setId( (yyval), (yyloc)); }
 #line 2382 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 73:
-#line 446 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 446 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxexprlist2((yyvsp[-2]), (yyvsp[0]), &(yylsp[0])); }
 #line 2388 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 74:
-#line 447 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 447 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = (yyvsp[-1]);}
 #line 2394 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 75:
-#line 450 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 450 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxsublist1((yyvsp[0]));	  }
 #line 2400 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 76:
-#line 451 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 451 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxsublist2((yyvsp[-3]),(yyvsp[0])); }
 #line 2406 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 77:
-#line 454 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 454 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxsub0();	 }
 #line 2412 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 78:
-#line 455 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 455 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxsub1((yyvsp[0]), &(yylsp[0]));  }
 #line 2418 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 79:
-#line 456 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 456 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxsymsub0((yyvsp[-1]), &(yylsp[-1])); 	modif_token( &(yylsp[0]), EQ_SUB ) ; modif_token( &(yylsp[-1]), SYMBOL_SUB ) ; }
 #line 2424 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 80:
-#line 457 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 457 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxsymsub1((yyvsp[-2]),(yyvsp[0]), &(yylsp[-2])); 	modif_token( &(yylsp[-1]), EQ_SUB ) ; modif_token( &(yylsp[-2]), SYMBOL_SUB ) ; }
 #line 2430 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 81:
-#line 458 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 458 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxsymsub0((yyvsp[-1]), &(yylsp[-1])); 	modif_token( &(yylsp[0]), EQ_SUB ) ; }
 #line 2436 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 82:
-#line 459 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 459 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxsymsub1((yyvsp[-2]),(yyvsp[0]), &(yylsp[-2])); 	modif_token( &(yylsp[-1]), EQ_SUB ) ; }
 #line 2442 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 83:
-#line 460 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 460 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxnullsub0(&(yylsp[-1])); 	modif_token( &(yylsp[0]), EQ_SUB ) ; }
 #line 2448 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 84:
-#line 461 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 461 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxnullsub1((yyvsp[0]), &(yylsp[-2])); 	modif_token( &(yylsp[-1]), EQ_SUB ) ; }
 #line 2454 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 85:
-#line 464 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 464 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxnullformal(); }
 #line 2460 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 86:
-#line 465 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 465 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxfirstformal0((yyvsp[0])); 	modif_token( &(yylsp[0]), SYMBOL_FORMALS ) ; }
 #line 2466 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 87:
-#line 466 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 466 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxfirstformal1((yyvsp[-2]),(yyvsp[0])); 	modif_token( &(yylsp[-2]), SYMBOL_FORMALS ) ; modif_token( &(yylsp[-1]), EQ_FORMALS ) ; }
 #line 2472 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 88:
-#line 467 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 467 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxaddformal0((yyvsp[-2]),(yyvsp[0]), &(yylsp[0]));   modif_token( &(yylsp[0]), SYMBOL_FORMALS ) ; }
 #line 2478 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 89:
-#line 469 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 469 "../../../src/main/gram.y" /* yacc.c:1646  */
     { (yyval) = xxaddformal1((yyvsp[-4]),(yyvsp[-2]),(yyvsp[0]),&(yylsp[-2])); modif_token( &(yylsp[-2]), SYMBOL_FORMALS ) ; modif_token( &(yylsp[-1]), EQ_FORMALS ) ;}
 #line 2484 "y.tab.c" /* yacc.c:1646  */
     break;
 
   case 90:
-#line 472 "../../../rho/src/main/gram.y" /* yacc.c:1646  */
+#line 472 "../../../src/main/gram.y" /* yacc.c:1646  */
     { EatLines = 1; }
 #line 2490 "y.tab.c" /* yacc.c:1646  */
     break;
@@ -2725,7 +2725,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 474 "../../../rho/src/main/gram.y" /* yacc.c:1906  */
+#line 474 "../../../src/main/gram.y" /* yacc.c:1906  */
 
 
 
@@ -4107,24 +4107,18 @@ static SEXP mkComplex(const char *s)
 
 static SEXP mkNA(void)
 {
-    SEXP t = allocVector(LGLSXP, 1);
-    LOGICAL(t)[0] = NA_LOGICAL;
-    return t;
+    return ScalarLogical(NA_LOGICAL);
 }
 
 attribute_hidden
 SEXP mkTrue(void)
 {
-    SEXP s = allocVector(LGLSXP, 1);
-    LOGICAL(s)[0] = 1;
-    return s;
+    return ScalarLogical(TRUE);
 }
 
 SEXP mkFalse(void)
 {
-    SEXP s = allocVector(LGLSXP, 1);
-    LOGICAL(s)[0] = 0;
-    return s;
+    return ScalarLogical(FALSE);
 }
 
 static void yyerror(const char *s)

--- a/src/main/gram.y
+++ b/src/main/gram.y
@@ -1852,24 +1852,18 @@ static SEXP mkComplex(const char *s)
 
 static SEXP mkNA(void)
 {
-    SEXP t = allocVector(LGLSXP, 1);
-    LOGICAL(t)[0] = NA_LOGICAL;
-    return t;
+    return ScalarLogical(NA_LOGICAL);
 }
 
 attribute_hidden
 SEXP mkTrue(void)
 {
-    SEXP s = allocVector(LGLSXP, 1);
-    LOGICAL(s)[0] = 1;
-    return s;
+    return ScalarLogical(TRUE);
 }
 
 SEXP mkFalse(void)
 {
-    SEXP s = allocVector(LGLSXP, 1);
-    LOGICAL(s)[0] = 0;
-    return s;
+    return ScalarLogical(FALSE);
 }
 
 static void yyerror(const char *s)


### PR DESCRIPTION
The parser allocated new scalars for each "TRUE", "FALSE" and "NA". This
makes the parser instead call ScalarLogical() which reuses global scalar
logicals.