### PR TITLE
Improve benchmark script, fix JIT benchmarking

### DIFF
--- a/bench/report.R
+++ b/bench/report.R
@@ -37,11 +37,13 @@ if (length(args) > 0) {
 
 read.stats <- function(rvm, version, timestamp) {
     filename <- paste(outdir, '/', rvm, '-', version, '.csv', sep='')
-    df <- read.csv(filename)
-    df$rvm <- rvm
-    df$version <- version
-    df$timestamp <- strptime(timestamp, "%Y-%m-%d %H:%M:%S")
-    df
+    if (file.exists(filename)) {
+        df <- read.csv(filename)
+        df$rvm <- rvm
+        df$version <- version
+        df$timestamp <- strptime(timestamp, "%Y-%m-%d %H:%M:%S")
+        df
+    }
 }
 
 merge.stats <- function(prev, rvm, version, timestamp) {

--- a/bench/runbench.py
+++ b/bench/runbench.py
@@ -129,16 +129,16 @@ def build_rho(gitref, args, jit, build=True):
                 subprocess.call(['git', 'clean', '-fd'])
                 subprocess.call(['git', 'clean', '-fX'])
             subprocess.call(['tools/rsync-recommended'])
+            # Use Clang to build (needed for the LLVM JIT build).
+            env = os.environ.copy()
+            env['CC'] = 'clang'
+            env['CXX'] = 'clang++'
             if jit:
                 # Build with JIT enabled.
-                # Need to use Clang for JIT build.
-                env = os.environ.copy()
-                env['CC'] = 'clang'
-                env['CXX'] = 'clang++'
                 # Requires llvm-config to be on PATH.
                 subprocess.call(['./configure', '--with-blas', '--with-lapack', '--enable-llvm-jit'], env=env)
             else:
-                subprocess.call(['./configure', '--with-blas', '--with-lapack'])
+                subprocess.call(['./configure', '--with-blas', '--with-lapack'], env=env)
             subprocess.call(['make', '-j2'])
     finally:
         os.chdir(bench_dir)


### PR DESCRIPTION
JIT benchmarking now compiles rho with Clang, which is required for
enabling the LLVM JIT compiler.

Added a few options to the runbench.py script: --skip-cr, --skip-jit,
and --no-clean.