### PR TITLE
Add allocator benchmarks + more benchmark options

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -5,3 +5,5 @@
 /report.pdf
 /tables.pdf
 /commits
+
+*.pyc

--- a/bench/allocbench.py
+++ b/bench/allocbench.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+
+#  R : A Computer Language for Statistical Data Analysis
+#  Copyright (C) 2016 and onwards the Rho Project Authors.
+#
+#  Rho is not part of the R project, and bugs and other issues should
+#  not be reported via r-bugs or other R project channels; instead refer
+#  to the Rho website.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, a copy is available at
+#  https://www.R-project.org/Licenses/
+
+# This script benchmarks a specific version of Rho and outputs the result in a
+# file in the output directory.
+#
+# 1. Take Rho git ref (hash) on command line to select version.
+# 2. Check out the selected Rho version into local rho directory.
+# 3. Build the Rho version.
+# 4. Run benchmarks and collect results into output directory.
+#
+# Output is generated into files with the naming scheme
+# out/rho(-jit)?-GITREF.csv # where GITREF is the Git reference.  For each
+# benchmark run, CR (GnuR) is also benchmarked to get a performance baseline.
+
+import benchmark
+import os
+
+
+# Allocator benchmarks are listed below:
+benchmarks = [
+    {'name': 'allocbench/small-lookup.R', 'warmup_rep': 0, 'bench_rep': 1},
+    {'name': 'allocbench/large-lookup.R', 'warmup_rep': 0, 'bench_rep': 1},
+    {'name': 'allocbench/huge-lookup.R', 'warmup_rep': 0, 'bench_rep': 1},
+    {'name': 'allocbench/small.R', 'warmup_rep': 0, 'bench_rep': 1},
+    {'name': 'allocbench/small-recursive.R', 'warmup_rep': 0, 'bench_rep': 1},
+    {'name': 'allocbench/small-reuse.R', 'warmup_rep': 0, 'bench_rep': 1},
+    {'name': 'allocbench/medium.R', 'warmup_rep': 0, 'bench_rep': 1},
+    {'name': 'allocbench/medium-recursive.R', 'warmup_rep': 0, 'bench_rep': 1},
+    {'name': 'allocbench/medium-reuse.R', 'warmup_rep': 0, 'bench_rep': 1},
+    {'name': 'allocbench/large.R', 'warmup_rep': 0, 'bench_rep': 1},
+    {'name': 'allocbench/large-recursive.R', 'warmup_rep': 0, 'bench_rep': 1},
+    {'name': 'allocbench/large-reuse.R', 'warmup_rep': 0, 'bench_rep': 1},
+    {'name': 'allocbench/huge.R', 'warmup_rep': 0, 'bench_rep': 1},
+    {'name': 'allocbench/huge-recursive.R', 'warmup_rep': 0, 'bench_rep': 1},
+    {'name': 'allocbench/huge-reuse.R', 'warmup_rep': 0, 'bench_rep': 1},
+    ]
+
+
+# The allocator benchmarks can not be run with any other Rho VM than Rho
+# because the native code used in the benchmarks depends on the Rho interface.
+# This could be changed by refactoring allocbench/allocator_test.cpp.
+def main():
+  args = benchmark.parse_args()
+  benchmark.setup_benchmarks(args)
+  for gitref in args.gitref:
+    # Build and benchmark Rho.
+    benchmark.benchmark_allocator(
+        benchmarks, gitref, args, benchmark.build_rho(gitref, args, jit=False))
+    if not args.skip_jit:
+      benchmark.benchmark_allocator(
+          benchmarks, gitref, args, benchmark.build_rho(gitref, args, jit=True))
+    # Update version list file to add newly benchmarked version:
+    with open(os.path.join(args.result_dir, 'versions'), 'a') as f:
+      print >>f, '%s, %s' % (gitref, benchmark.get_timestamp(gitref, args))
+
+
+if __name__ == '__main__':
+  main()

--- a/bench/allocbench/allocator_test.cpp
+++ b/bench/allocbench/allocator_test.cpp
@@ -1,0 +1,182 @@
+/*
+ *  R : A Computer Language for Statistical Data Analysis
+ *  Copyright (C) 2016 and onwards the Rho Project Authors.
+ *
+ *  Rho is not part of the R project, and bugs and other issues should
+ *  not be reported via r-bugs or other R project channels; instead refer
+ *  to the Rho website.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, a copy is available at
+ *  https://www.R-project.org/Licenses/
+ */
+
+#define COMPILING_RHO
+#include "rho/IntVector.hpp"
+#include "rho/GCStackRoot.hpp"
+#include "rho/MemoryBank.hpp"
+//#include "rho/BlockPool.hpp"
+
+using namespace rho;
+
+#ifdef DEBUG_INFO
+void print_sparse_table();
+#endif
+
+#define NUM_ALLOCS (1000000)
+
+// Allocates various sized int vectors before running each allocation test.
+// This is meant to simulate non-uniform allocation patterns before we
+// start allocating only same-size objects.
+static void alloc_various_intvec() {
+    for (int i = 1; i < 50; ++i) {
+        if (i < 20) {
+            IntVector::create(i);
+        } else {
+            IntVector::create(i * 10);
+        }
+    }
+}
+
+// Allocate NUM_ALLOCS * size int-vectors.
+// Stress the allocator by allocating very many int-vectors.
+// The allocations are not freed so this forces the allocator to continue
+// allocating more and more memory.
+extern "C"
+SEXP alloc_intvec(int* num, int* size) {
+    alloc_various_intvec();
+    void* allocations[*num];
+    for (int i = 0; i < *num; ++i) {
+        allocations[i] = IntVector::create(*size);
+    }
+    return nullptr;
+}
+
+// Allocate NUM_ALLOCS * size int-vectors.
+// Stress the allocator by allocating very many int-vectors.
+// The allocations are not freed so this forces the allocator to continue
+// allocating more and more memory.
+extern "C"
+SEXP alloc_reuse_intvec(int* num, int* each, int* size) {
+    alloc_various_intvec();
+    for (int i = 0; i < ((*num + *each - 1) / *each); ++i) {
+        alloc_intvec(each, size);
+    }
+    return nullptr;
+}
+
+// Recursively calling a function that makes stack allocations tests the
+// pointer lookup.
+extern "C"
+SEXP alloc_recursive_intvec(int* num, int* each, int* size) {
+    alloc_various_intvec();
+    if (*num > 0) {
+        void* allocations[*each];
+        for (int i = 0; i < *each; ++i) {
+            allocations[i] = IntVector::create(*size);
+        }
+        *num -= *each;
+        alloc_recursive_intvec(num, each, size);
+    }
+    return nullptr;
+}
+
+extern "C"
+SEXP alloc_scalar(int* num) {
+    alloc_various_intvec();
+    void* allocations[*num];
+    for (int i = 0; i < *num; ++i) {
+        allocations[i] = ScalarInteger(i);
+    }
+    return nullptr;
+}
+
+// Allocate NUM_ALLOCS * size int-vectors.
+// Stress the allocator by allocating very many int-vectors.
+// The allocations are not freed so this forces the allocator to continue
+// allocating more and more memory.
+extern "C"
+SEXP alloc_reuse_scalar(int* num, int* each) {
+    alloc_various_intvec();
+    for (int i = 0; i < ((*num + *each - 1) / *each); ++i) {
+        alloc_scalar(each);
+    }
+    return nullptr;
+}
+
+// Recursively calling a function that makes stack allocations tests the
+// pointer lookup.
+extern "C"
+SEXP alloc_recursive_scalar(int* num, int* each) {
+    alloc_various_intvec();
+    if (*num > 0) {
+        void* allocations[*each];
+        for (int i = 0; i < *each; ++i) {
+            allocations[i] = ScalarInteger(i);
+        }
+        *num -= *each;
+        alloc_recursive_scalar(num, each);
+    }
+    return nullptr;
+}
+
+extern "C"
+SEXP alloc_lookup_scalar(int* num, int* lookups) {
+    alloc_various_intvec();
+    void* allocations[*num];
+    for (int i = 0; i < *num; ++i) {
+        allocations[i] = ScalarInteger(i);
+    }
+    for (int k = 0; k < *lookups; ++k) {
+        // Exact pointer lookup.
+        for (int i = 0; i < *num; ++i) {
+            GCNode::asGCNode(allocations[i]);
+        }
+        // Lookup 1 byte inside allocation.
+        for (int i = 0; i < *num; ++i) {
+            GCNode::asGCNode(reinterpret_cast<char*>(allocations[i]) + 1);
+        }
+        // Lookup 40 bytes inside allocation.
+        for (int i = 0; i < *num; ++i) {
+            GCNode::asGCNode(reinterpret_cast<char*>(allocations[i]) + 40);
+        }
+    }
+    // TODO: add test for lookup misses?
+    return nullptr;
+}
+
+extern "C"
+SEXP alloc_lookup_intvec(int* num, int* lookups, int* size) {
+    alloc_various_intvec();
+    void* allocations[*num];
+    for (int i = 0; i < *num; ++i) {
+        allocations[i] = IntVector::create(*size);
+    }
+    for (int k = 0; k < *lookups; ++k) {
+        // Exact pointer lookup.
+        for (int i = 0; i < *num; ++i) {
+            GCNode::asGCNode(allocations[i]);
+        }
+        // Lookup 1 byte inside allocation.
+        for (int i = 0; i < *num; ++i) {
+            GCNode::asGCNode(reinterpret_cast<char*>(allocations[i]) + 1);
+        }
+        // Lookup at the end of the allocation.
+        for (int i = 0; i < *num; ++i) {
+            GCNode::asGCNode(reinterpret_cast<char*>(allocations[i]) + (*size - 1));
+        }
+    }
+    // TODO: add test for lookup misses?
+    return nullptr;
+}
+

--- a/bench/allocbench/huge-lookup.R
+++ b/bench/allocbench/huge-lookup.R
@@ -1,0 +1,2 @@
+dyn.load('allocator_test.so')
+.C('alloc_lookup_intvec', as.integer(100), as.integer(100000), as.integer(100000))

--- a/bench/allocbench/huge-recursive.R
+++ b/bench/allocbench/huge-recursive.R
@@ -1,0 +1,2 @@
+dyn.load('allocator_test.so')
+.C('alloc_recursive_intvec', as.integer(100), as.integer(2), as.integer(100000))

--- a/bench/allocbench/huge-reuse.R
+++ b/bench/allocbench/huge-reuse.R
@@ -1,0 +1,2 @@
+dyn.load('allocator_test.so')
+.C('alloc_intvec', as.integer(10000), as.integer(20), as.integer(100000))

--- a/bench/allocbench/huge.R
+++ b/bench/allocbench/huge.R
@@ -1,0 +1,2 @@
+dyn.load('allocator_test.so')
+.C('alloc_intvec', as.integer(100), as.integer(100000))

--- a/bench/allocbench/large-lookup.R
+++ b/bench/allocbench/large-lookup.R
@@ -1,0 +1,2 @@
+dyn.load('allocator_test.so')
+.C('alloc_lookup_intvec', as.integer(1000), as.integer(50000), as.integer(1000))

--- a/bench/allocbench/large-recursive.R
+++ b/bench/allocbench/large-recursive.R
@@ -1,0 +1,2 @@
+dyn.load('allocator_test.so')
+.C('alloc_recursive_intvec', as.integer(10000), as.integer(100), as.integer(1000))

--- a/bench/allocbench/large-reuse.R
+++ b/bench/allocbench/large-reuse.R
@@ -1,0 +1,2 @@
+dyn.load('allocator_test.so')
+.C('alloc_intvec', as.integer(20000), as.integer(200), as.integer(1000))

--- a/bench/allocbench/large.R
+++ b/bench/allocbench/large.R
@@ -1,0 +1,2 @@
+dyn.load('allocator_test.so')
+.C('alloc_intvec', as.integer(10000), as.integer(1000))

--- a/bench/allocbench/medium-recursive.R
+++ b/bench/allocbench/medium-recursive.R
@@ -1,0 +1,2 @@
+dyn.load('allocator_test.so')
+.C('alloc_recursive_intvec', as.integer(50000), as.integer(100), as.integer(50))

--- a/bench/allocbench/medium-reuse.R
+++ b/bench/allocbench/medium-reuse.R
@@ -1,0 +1,2 @@
+dyn.load('allocator_test.so')
+.C('alloc_reuse_intvec', as.integer(500000), as.integer(1000), as.integer(50))

--- a/bench/allocbench/medium.R
+++ b/bench/allocbench/medium.R
@@ -1,0 +1,2 @@
+dyn.load('allocator_test.so')
+.C('alloc_intvec', as.integer(50000), as.integer(50))

--- a/bench/allocbench/small-lookup.R
+++ b/bench/allocbench/small-lookup.R
@@ -1,0 +1,3 @@
+dyn.load('allocator_test.so')
+# Do very many pointer lookups.
+.C('alloc_lookup_scalar', as.integer(100000), as.integer(1000))

--- a/bench/allocbench/small-recursive.R
+++ b/bench/allocbench/small-recursive.R
@@ -1,0 +1,2 @@
+dyn.load('allocator_test.so')
+.C('alloc_recursive_scalar', as.integer(50000), as.integer(1000))

--- a/bench/allocbench/small-reuse.R
+++ b/bench/allocbench/small-reuse.R
@@ -1,0 +1,2 @@
+dyn.load('allocator_test.so')
+.C('alloc_reuse_scalar', as.integer(1000000), as.integer(500))

--- a/bench/allocbench/small.R
+++ b/bench/allocbench/small.R
@@ -1,0 +1,2 @@
+dyn.load('allocator_test.so')
+.C('alloc_scalar', as.integer(100000))

--- a/bench/benchmark.py
+++ b/bench/benchmark.py
@@ -1,0 +1,277 @@
+#!/usr/bin/python
+
+#  R : A Computer Language for Statistical Data Analysis
+#  Copyright (C) 2016 and onwards the Rho Project Authors.
+#
+#  Rho is not part of the R project, and bugs and other issues should
+#  not be reported via r-bugs or other R project channels; instead refer
+#  to the Rho website.
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, a copy is available at
+#  https://www.R-project.org/Licenses/
+
+# This script benchmarks a specific version of Rho and outputs the result in a
+# file in the output directory.
+#
+# 1. Take Rho git ref (hash) on command line to select version.
+# 2. Check out the selected Rho version into local rho directory.
+# 3. Build the Rho version.
+# 4. Run benchmarks and collect results into output directory.
+#
+# Output is generated into files with the naming scheme
+# out/rho(-jit)?-GITREF.csv # where GITREF is the Git reference.  For each
+# benchmark run, CR (GnuR) is also benchmarked to get a performance baseline.
+
+import argparse
+import ConfigParser
+import os
+from os.path import normpath
+import re
+import subprocess
+
+
+def parse_args():
+  parser = argparse.ArgumentParser(
+      description='''Runs R benchmarks for a specific version of Rho.''')
+  parser.add_argument(
+      'gitref', nargs='+',
+      help='The Rho git reference to benchmark')
+  parser.add_argument(
+      '--repository', default='git@github.com:rho-devel/rho',
+      help='The git repository to clone from.')
+  parser.add_argument(
+      '--build_dir', default='rho',
+      help=('The directory to build Rho in. '
+            'The Rho repository is cloned into this directory.'))
+  parser.add_argument(
+      '--result_dir', default='out',
+      help='The output directory to store benchmark results in.')
+  parser.add_argument(
+      '--skip-cr', dest='skip_cr', action='store_true',
+      help='Skips benchmarking CR as baseline.')
+  parser.add_argument(
+      '--skip-jit', dest='skip_jit', action='store_true',
+      help='Skips benchmarking the JIT variants.')
+  parser.add_argument(
+      '--no-clean', dest='no_clean', action='store_true',
+      help=('The build directory is not cleaned before building each '
+            'Rho revision. This speeds up the benchmarking process but '
+            'may affect accuracy.'))
+  parser.add_argument(
+      '--no-build', dest='no_build', action='store_true',
+      help=('Skips building rho. '
+            'Use only for re-running a single benchmark.'))
+  parser.add_argument(
+      '--timestamp',
+      help='Manually specified version timestamp (output in out/versions).')
+  args = parser.parse_args()
+  return args
+
+
+# Set up RVM parameters to run Gnu R.
+def use_cr(jit):
+  if jit:
+    return {'name': 'R-bytecode', 'id': 'cr-jit', 'command': 'R'}
+  else:
+    return {'name': 'R', 'id': 'cr', 'command': 'R'}
+
+
+def build_rho(gitref, args, jit):
+  bench_dir = os.getcwd()
+  rvm = {'name': 'Rho'}
+  if jit:
+    rvm['id'] = 'rho-jit'
+  else:
+    rvm['id'] = 'rho'
+  if not args.no_build:
+    try:
+      os.chdir(args.build_dir)
+      if not os.path.isdir('.git'):
+        # Clone Rho into the local directory.
+        exit_code = subprocess.call(['git', 'clone', args.repository, '.'])
+        if exit_code != 0:
+          raise Exception('Failed to fetch rho version %s' % gitref)
+      else:
+        # Fetch latest commits.
+        exit_code = subprocess.call(['git', 'fetch', 'origin'])
+        if exit_code != 0:
+          raise Exception('Failed to fetch latest rho commits')
+      # Clean and switch to the selected revision.
+      exit_code = subprocess.call(['git', 'reset', '--hard', gitref])
+      if exit_code != 0:
+        raise Exception('Failed to switch to specified rho commit: %s' % gitref)
+      if not args.no_clean:
+        subprocess.call(['git', 'clean', '-fd'])
+        subprocess.call(['git', 'clean', '-fX'])
+        subprocess.call(['tools/rsync-recommended'])
+        # Use Clang to build (needed for the LLVM JIT build).
+        env = os.environ.copy()
+        env['CC'] = 'clang'
+        env['CXX'] = 'clang++'
+        if jit:
+          # Build with JIT enabled.
+          # Requires llvm-config to be on PATH.
+          subprocess.call([
+              './configure', '--with-blas', '--with-lapack',
+              '--enable-llvm-jit'], env=env)
+        else:
+          subprocess.call([
+              './configure', '--with-blas', '--with-lapack'], env=env)
+        subprocess.call(['make', '-j2'])
+    finally:
+      os.chdir(bench_dir)
+  # Create a new config file because the benchmark suite is not aware of our
+  # Rho build.
+  rvm['cfg_file'] = write_config(args, jit)
+  rvm['command'] = os.path.realpath('%s/bin/rho' % args.build_dir)
+  return rvm
+
+
+# Returns the timestamp for a Git reference.
+def get_timestamp(gitref, args):
+  if args.timestamp:
+    return args.timestamp
+  bench_dir = os.getcwd()
+  try:
+    os.chdir(args.build_dir)
+    return subprocess.check_output([
+        'git', 'show', '-s', '--format=%ci', gitref, '--'])
+  finally:
+    os.chdir(bench_dir)
+
+
+# Write custom config file for running Rho in the benchmark suite.
+def write_config(args, jit):
+  config = ConfigParser.RawConfigParser()
+  config.add_section('GENERAL')
+  config.set('GENERAL', 'WARMUP_REP', 2)
+  config.set('GENERAL', 'BENCH_REP', 5)
+  config.set('GENERAL', 'PERF_TMP', '_perf.tmp')
+  config.set('GENERAL', 'PERF_REP', 1)
+  config.set('GENERAL', 'PERF_CMD',
+             'perf stat -r %(PERF_REP)s -x, -o %(PERF_TMP)s --append')
+  config.add_section('Rho')
+  if jit:
+    config.set('Rho', 'ENV', 'R_COMPILE_PKGS=1 R_ENABLE_JIT=2')
+  else:
+    config.set('Rho', 'ENV', 'R_COMPILE_PKGS=0 R_ENABLE_JIT=0')
+  config.set('Rho', 'HOME', os.path.realpath('%s/bin' % args.build_dir))
+  config.set('Rho', 'CMD', 'Rscript')
+  config.set('Rho', 'ARGS', '--vanilla')
+  config.set('Rho', 'HARNESS', 'r_harness.R')
+  config.set('Rho', 'HARNESS_ARGS', 'FALSE')
+  cfg_file = normpath('%s/rho.cfg' % args.result_dir)
+  with open(cfg_file, 'wb') as f:
+    config.write(f)
+  return cfg_file
+
+
+# Runs the benchmark suite on a single R version.
+def bench(benchmarks, gitref, args, rvm):
+  print('Starting benchmark runs for commit %s with RVM %s.'
+        % (gitref, rvm['name']))
+  for bm in benchmarks:
+    bench_cmd = [
+        'python', normpath('benchmarks/utility/rbench.py'),
+        normpath(bm['name']),
+        '--rvm', rvm['name'],
+        '--warmup_rep', '%d' % bm['warmup_rep'],
+        '--bench_rep', '%d' % bm['bench_rep'],
+        '--timingfile',
+        normpath('%s/%s-%s.csv' % (args.result_dir, rvm['id'], gitref))]
+    if 'cfg_file' in rvm:
+      bench_cmd += ['--config', rvm['cfg_file']]
+      output = subprocess.check_output(bench_cmd)
+      for line in output.splitlines():
+        if line.startswith('[rbench]benchmarks'):
+          print(line)
+        elif line.startswith('nan,time'):
+          print(line)
+        elif re.match(r'\d+.*,time', line):
+          print(line)
+
+
+# Runs an allocator benchmark suite on a single R version.
+def benchmark_allocator(benchmarks, gitref, args, rvm):
+  # First, build the allocator_test C library.
+  bench_dir = os.getcwd()
+  try:
+    os.chdir('allocbench')
+    try:
+      os.remove('allocator_test.o')
+    except OSError:
+      pass
+    try:
+      os.remove('allocator_test.so')
+    except OSError:
+      pass
+    subprocess.call([
+        rvm['command'],
+        'CMD',
+        'SHLIB',
+        'allocator_test.cpp'])
+  finally:
+    os.chdir(bench_dir)
+  print('Starting benchmark runs for commit %s with RVM %s.'
+        % (gitref, rvm['name']))
+  for bm in benchmarks:
+    bench_cmd = [
+        'python', normpath('benchmarks/utility/rbench.py'),
+        normpath(bm['name']),
+        '--rvm', rvm['name'],
+        '--warmup_rep', '%d' % bm['warmup_rep'],
+        '--bench_rep', '%d' % bm['bench_rep'],
+        '--meter=system.time',
+        '--timingfile',
+        normpath('%s/%s-%s.csv' % (args.result_dir, rvm['id'], gitref))]
+    if 'cfg_file' in rvm:
+      bench_cmd += ['--config', rvm['cfg_file']]
+      output = subprocess.check_output(bench_cmd)
+      for line in output.splitlines():
+        if line.startswith('[rbench]benchmarks'):
+          print(line)
+        elif line.startswith('nan,time'):
+          print(line)
+        elif re.match(r'\d+.*,time', line):
+          print(line)
+
+
+# Set up the benchmark suite. Generates input data for the benchmarks that need
+# input data.
+# Also creates the build and result directories if they don't already exist.
+def setup_benchmarks(args):
+  if not os.path.isdir(args.build_dir):
+    os.mkdir(args.build_dir)
+  if not os.path.isdir(args.result_dir):
+    os.mkdir(args.result_dir)
+  if not os.path.isdir('benchmarks'):
+    # Clone the benchmark suite.
+    subprocess.call(['git', 'clone', 'git@github.com:rho-devel/benchmarks.git',
+                     'benchmarks'])
+    bench_dir = os.getcwd()
+    try:
+      # Generate benchmark input data.
+      os.chdir(normpath('benchmarks/riposte'))
+      subprocess.call([
+          'curl',
+          'https://cran.r-project.org/src/contrib/clusterGeneration_1.3.4.tar.gz',
+          '-o', 'clusterGeneration_1.3.4.tar.gz'])
+      subprocess.call(['R', 'CMD', 'INSTALL', 'clusterGeneration_1.3.4.tar.gz'])
+      os.mkdir('data')
+      subprocess.call(['Rscript', 'gen_kmeans.R'])
+      subprocess.call(['Rscript', 'gen_lr.R'])
+      subprocess.call(['Rscript', 'gen_pca.R'])
+    finally:
+      os.chdir(bench_dir)
+

--- a/bench/runbench.py
+++ b/bench/runbench.py
@@ -33,12 +33,8 @@
 # out/rho(-jit)?-GITREF.csv # where GITREF is the Git reference.  For each
 # benchmark run, CR (GnuR) is also benchmarked to get a performance baseline.
 
-import argparse
-import ConfigParser
+import benchmark
 import os
-from os.path import normpath
-import re
-import subprocess
 
 
 # This list contains benchmarks to run and the number of warmup/bench runs for
@@ -79,209 +75,24 @@ benchmarks = [
     ]
 
 
-def parse_args():
-  parser = argparse.ArgumentParser(
-      description='''Runs R benchmarks for a specific version of Rho.''')
-  parser.add_argument(
-      'gitref', nargs='+',
-      help='The Rho git reference to benchmark')
-  parser.add_argument(
-      '--repository', default='git@github.com:rho-devel/rho',
-      help='The git repository to clone from.')
-  parser.add_argument(
-      '--build_dir', default='rho',
-      help=('The directory to build Rho in. '
-            'The Rho repository is cloned into this directory.'))
-  parser.add_argument(
-      '--result_dir', default='out',
-      help='The output directory to store benchmark results in.')
-  parser.add_argument(
-      '--skip-cr', dest='skip_cr', action='store_true',
-      help='Skips benchmarking CR as baseline.')
-  parser.add_argument(
-      '--skip-jit', dest='skip_jit', action='store_true',
-      help='Skips benchmarking the JIT variants.')
-  parser.add_argument(
-      '--no-clean', dest='no_clean', action='store_true',
-      help=('The build directory is not cleaned before building each '
-            'Rho revision. This speeds up the benchmarking process but '
-            'may affect accuracy.'))
-  parser.add_argument(
-      '--no-build', dest='no_build', action='store_true',
-      help=('Skips building rho. '
-            'Use only for re-running a single benchmark.'))
-  parser.add_argument(
-      '--timestamp',
-      help='Manually specified version timestamp (output in out/versions).')
-  args = parser.parse_args()
-  return args
-
-
-# Set up RVM parameters to run Gnu R.
-def use_cr(jit):
-  if jit:
-    return {'name': 'R-bytecode', 'id': 'cr-jit', 'command': 'R'}
-  else:
-    return {'name': 'R', 'id': 'cr', 'command': 'R'}
-
-
-def build_rho(gitref, args, jit):
-  bench_dir = os.getcwd()
-  rvm = {'name': 'Rho'}
-  if jit:
-    rvm['id'] = 'rho-jit'
-  else:
-    rvm['id'] = 'rho'
-  if not args.no_build:
-    try:
-      os.chdir(args.build_dir)
-      if not os.path.isdir('.git'):
-        # Clone Rho into the local directory.
-        exit_code = subprocess.call(['git', 'clone', args.repository, '.'])
-        if exit_code != 0:
-          raise Exception('Failed to fetch rho version %s' % gitref)
-      else:
-        # Fetch latest commits.
-        exit_code = subprocess.call(['git', 'fetch', 'origin'])
-        if exit_code != 0:
-          raise Exception('Failed to fetch latest rho commits')
-      # Clean and switch to the selected revision.
-      subprocess.call(['git', 'reset', '--hard', gitref])
-      if not args.no_clean:
-        subprocess.call(['git', 'clean', '-fd'])
-        subprocess.call(['git', 'clean', '-fX'])
-        subprocess.call(['tools/rsync-recommended'])
-        # Use Clang to build (needed for the LLVM JIT build).
-        env = os.environ.copy()
-        env['CC'] = 'clang'
-        env['CXX'] = 'clang++'
-        if jit:
-          # Build with JIT enabled.
-          # Requires llvm-config to be on PATH.
-          subprocess.call([
-              './configure', '--with-blas', '--with-lapack',
-              '--enable-llvm-jit'], env=env)
-        else:
-          subprocess.call([
-              './configure', '--with-blas', '--with-lapack'], env=env)
-        subprocess.call(['make', '-j2'])
-    finally:
-      os.chdir(bench_dir)
-  # Create a new config file because the benchmark suite is not aware of our
-  # Rho build.
-  rvm['cfg_file'] = write_config(args, jit)
-  rvm['command'] = os.path.realpath('%s/bin/rho' % args.build_dir)
-  return rvm
-
-
-# Returns the timestamp for a Git reference.
-def get_timestamp(gitref, args):
-  if args.timestamp:
-    return args.timestamp
-  bench_dir = os.getcwd()
-  try:
-    os.chdir(args.build_dir)
-    return subprocess.check_output([
-        'git', 'show', '-s', '--format=%ci', gitref, '--'])
-  finally:
-    os.chdir(bench_dir)
-
-
-# Write custom config file for running Rho in the benchmark suite.
-def write_config(args, jit):
-  config = ConfigParser.RawConfigParser()
-  config.add_section('GENERAL')
-  config.set('GENERAL', 'WARMUP_REP', 2)
-  config.set('GENERAL', 'BENCH_REP', 5)
-  config.set('GENERAL', 'PERF_TMP', '_perf.tmp')
-  config.set('GENERAL', 'PERF_REP', 1)
-  config.set('GENERAL', 'PERF_CMD',
-             'perf stat -r %(PERF_REP)s -x, -o %(PERF_TMP)s --append')
-  config.add_section('Rho')
-  if jit:
-    config.set('Rho', 'ENV', 'R_COMPILE_PKGS=1 R_ENABLE_JIT=2')
-  else:
-    config.set('Rho', 'ENV', 'R_COMPILE_PKGS=0 R_ENABLE_JIT=0')
-  config.set('Rho', 'HOME', os.path.realpath('%s/bin' % args.build_dir))
-  config.set('Rho', 'CMD', 'Rscript')
-  config.set('Rho', 'ARGS', '--vanilla')
-  config.set('Rho', 'HARNESS', 'r_harness.R')
-  config.set('Rho', 'HARNESS_ARGS', 'FALSE')
-  cfg_file = normpath('%s/rho.cfg' % args.result_dir)
-  with open(cfg_file, 'wb') as f:
-    config.write(f)
-  return cfg_file
-
-
-# Runs the benchmark suite on a single R version.
-def bench(gitref, args, rvm):
-  print('Starting benchmark runs for commit %s with RVM %s.'
-        % (gitref, rvm['name']))
-  for bm in benchmarks:
-    bench_cmd = [
-        'python', normpath('benchmarks/utility/rbench.py'),
-        normpath(bm['name']),
-        '--rvm', rvm['name'],
-        '--warmup_rep', '%d' % bm['warmup_rep'],
-        '--bench_rep', '%d' % bm['bench_rep'],
-        '--timingfile',
-        normpath('%s/%s-%s.csv' % (args.result_dir, rvm['id'], gitref))]
-    if 'cfg_file' in rvm:
-      bench_cmd += ['--config', rvm['cfg_file']]
-      output = subprocess.check_output(bench_cmd)
-      for line in output.splitlines():
-        if line.startswith('[rbench]benchmarks'):
-          print(line)
-        elif line.startswith('nan,time'):
-          print(line)
-        elif re.match(r'\d+.*,time', line):
-          print(line)
-
-
-# Set up the benchmark suite. Generates input data for the benchmarks that need
-# input data.
-def setup_benchmarks():
-  # Clone the benchmark suite.
-  subprocess.call(['git', 'clone', 'git@github.com:rho-devel/benchmarks.git',
-                   'benchmarks'])
-  bench_dir = os.getcwd()
-  try:
-    # Generate benchmark input data.
-    os.chdir(normpath('benchmarks/riposte'))
-    subprocess.call([
-        'curl',
-        'https://cran.r-project.org/src/contrib/clusterGeneration_1.3.4.tar.gz',
-        '-o', 'clusterGeneration_1.3.4.tar.gz'])
-    subprocess.call(['R', 'CMD', 'INSTALL', 'clusterGeneration_1.3.4.tar.gz'])
-    os.mkdir('data')
-    subprocess.call(['Rscript', 'gen_kmeans.R'])
-    subprocess.call(['Rscript', 'gen_lr.R'])
-    subprocess.call(['Rscript', 'gen_pca.R'])
-  finally:
-    os.chdir(bench_dir)
-
-
 def main():
-  args = parse_args()
-  if not os.path.isdir('benchmarks'):
-    setup_benchmarks()
-  if not os.path.isdir(args.build_dir):
-    os.mkdir(args.build_dir)
-  if not os.path.isdir(args.result_dir):
-    os.mkdir(args.result_dir)
+  args = benchmark.parse_args()
+  benchmark.setup_benchmarks(args)
   for gitref in args.gitref:
     # Build and benchmark Rho.
-    bench(gitref, args, build_rho(gitref, args, jit=False))
+    benchmark.bench(
+        benchmarks, gitref, args, benchmark.build_rho(gitref, args, jit=False))
     if not args.skip_jit:
-      bench(gitref, args, build_rho(gitref, args, jit=True))
+      benchmark.bench(
+          benchmarks, gitref, args, benchmark.build_rho(gitref, args, jit=True))
     # Also run CR to get a baseline for performance.
     if not args.skip_cr:
-      bench(gitref, args, use_cr(jit=False))
+      benchmark.bench(benchmarks, gitref, args, benchmark.use_cr(jit=False))
       if not args.skip_jit:
-        bench(gitref, args, use_cr(jit=True))
+        benchmark.bench(benchmarks, gitref, args, benchmark.use_cr(jit=True))
     # Update version list file to add newly benchmarked version:
     with open(os.path.join(args.result_dir, 'versions'), 'a') as f:
-      print >>f, '%s, %s' % (gitref, get_timestamp(gitref, args))
+      print >>f, '%s, %s' % (gitref, benchmark.get_timestamp(gitref, args))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added two new options to the benchmark script:

* --timestamp allows manually specifying the timestamp for the
  benchmarked version.
* --no-build skips building Rho before running a benchmark. Useful when
  re-running the benchmark for a single version.

This also adds new benchmarks for benchmarking the Rho allocator.