### PR TITLE
Experimental coalesced reference counting

### DIFF
--- a/src/include/rho/ArgMatcher.hpp
+++ b/src/include/rho/ArgMatcher.hpp
@@ -35,7 +35,6 @@
 #include "boost/range.hpp"
 #include "rho/ArgList.hpp"
 #include "rho/Frame.hpp"
-#include "rho/GCEdge.hpp"
 #include "rho/Promise.hpp"
 #include "rho/String.hpp"
 
@@ -283,6 +282,7 @@ namespace rho {
 
 	// Virtual function of GCNode:
 	void visitReferents(const_visitor* v) const override;
+        void applyToCoalescedReferences(std::function<void(const GCNode*)> fun) const override;
 
 	class MatchCallback;
     protected:
@@ -301,7 +301,7 @@ namespace rho {
 
 	enum MatchStatus {UNMATCHED = 0, EXACT_TAG, PARTIAL_TAG, POSITIONAL};
 
-	GCEdge<const PairList> m_formals;
+	const PairList* m_formals;
 
 	// Data on formals (including "...") in order of occurrence:
 	typedef std::vector<FormalData, Allocator<FormalData> > FormalVector;

--- a/src/include/rho/Closure.hpp
+++ b/src/include/rho/Closure.hpp
@@ -75,9 +75,11 @@ namespace rho {
 	Closure(const Closure& pattern)
 	    : FunctionBase(pattern), m_debug(false),
               m_num_invokes(0),
-	      m_matcher(pattern.m_matcher), m_body(pattern.m_body),
+	      m_body(pattern.m_body),
 	      m_environment(pattern.m_environment)
-	{}
+	{
+            attachReference(m_matcher, pattern.m_matcher);
+        }
 
 	/** @brief Access the body of the Closure.
 	 *
@@ -218,6 +220,7 @@ namespace rho {
 
 	// Virtual function of GCNode:
 	void visitReferents(const_visitor* v) const override;
+        void applyToCoalescedReferences(std::function<void(const GCNode*)> fun) const override;
 
         void compile() const;
     protected:
@@ -271,7 +274,7 @@ namespace rho {
         mutable int m_num_invokes;
         mutable GCEdge<JIT::CompiledExpression> m_compiled_body;
 
-	GCEdge<const ArgMatcher> m_matcher;
+	const ArgMatcher* m_matcher = nullptr;
 	GCEdge<> m_body;
 	GCEdge<Environment> m_environment;
         static bool s_debugging_enabled;

--- a/src/include/rho/Closure.hpp
+++ b/src/include/rho/Closure.hpp
@@ -75,10 +75,10 @@ namespace rho {
 	Closure(const Closure& pattern)
 	    : FunctionBase(pattern), m_debug(false),
               m_num_invokes(0),
-	      m_body(pattern.m_body),
 	      m_environment(pattern.m_environment)
 	{
             attachReference(m_matcher, pattern.m_matcher);
+            attachReference(m_body, pattern.m_body);
         }
 
 	/** @brief Access the body of the Closure.
@@ -275,7 +275,7 @@ namespace rho {
         mutable GCEdge<JIT::CompiledExpression> m_compiled_body;
 
 	const ArgMatcher* m_matcher = nullptr;
-	GCEdge<> m_body;
+	RObject* m_body;
 	GCEdge<Environment> m_environment;
         static bool s_debugging_enabled;
 

--- a/src/include/rho/RObject.hpp
+++ b/src/include/rho/RObject.hpp
@@ -499,12 +499,10 @@ namespace rho {
 	virtual void unpackGPBits(unsigned int gpbits);
 
 	// Virtual functions of GCNode:
-	void detachReferents() override
-	{
-	    m_attrib.detach();
-	}
+	void detachReferents() override;
 
 	void visitReferents(const_visitor* v) const override;
+        void applyToCoalescedReferences(std::function<void(const GCNode*)> fun) const override;
     protected:
 	/**
 	 * @param stype Required type of the RObject.
@@ -571,7 +569,7 @@ namespace rho {
 	bool m_active_binding : 1;
 	bool m_binding_locked : 1;
     private:
-	GCEdge<PairList> m_attrib;
+	PairList* m_attrib = nullptr; // Must always be initialized.
 
 #ifdef R_MEMORY_PROFILING
 	// This function implements maybeTraceMemory() (qv.) when

--- a/src/main/ArgMatcher.cpp
+++ b/src/main/ArgMatcher.cpp
@@ -50,7 +50,7 @@ bool ArgMatcher::s_warn_on_partial_match = false;
 ArgMatcher::ArgMatcher(const PairList* formals)
     : m_dots_position(-1)
 {
-    m_formals = formals;
+    attachReference(m_formals, formals);
 
     for (const PairList* f = formals; f; f = f->tail()) {
 	const Symbol* sym = dynamic_cast<const Symbol*>(f->tag());
@@ -78,7 +78,7 @@ ArgMatcher::ArgMatcher(const PairList* formals)
 
 void ArgMatcher::detachReferents()
 {
-    m_formals.detach();
+    detachReference(m_formals);
     m_formal_data.clear();
     m_formal_index.clear();
 }
@@ -491,6 +491,13 @@ void ArgMatcher::visitReferents(const_visitor* v) const
 {
     if (m_formals)
 	(*v)(m_formals);
+}
+
+void ArgMatcher::applyToCoalescedReferences(std::function<void(const GCNode*)> fun) const
+{
+    if (m_formals) {
+	fun(m_formals);
+    }
 }
 
 PairList* ArgMatcher::makePairList(std::initializer_list<const char*> arg_names)

--- a/src/main/Closure.cpp
+++ b/src/main/Closure.cpp
@@ -69,7 +69,7 @@ Closure::Closure(const PairList* formal_args, RObject* body, Environment* env)
     : FunctionBase(CLOSXP), m_debug(false),
       m_num_invokes(0)
 {
-    m_matcher = new ArgMatcher(formal_args);
+    attachReference(m_matcher, new ArgMatcher(formal_args));
     m_body = body;
     m_environment = env;
 }
@@ -87,7 +87,7 @@ Closure* Closure::clone() const
 
 void Closure::detachReferents()
 {
-    m_matcher.detach();
+    detachReference(m_matcher);
     m_body.detach();
     m_environment.detach();
     m_compiled_body.detach();
@@ -166,7 +166,7 @@ void Closure::setEnvironment(Environment* new_env) {
 }
 
 void Closure::setFormals(PairList* formals) {
-    m_matcher = new ArgMatcher(formals);
+    retargetReference(m_matcher, new ArgMatcher(formals));
     invalidateCompiledCode();
 }
 
@@ -196,6 +196,16 @@ void Closure::visitReferents(const_visitor* v) const
 	(*v)(environment);
     if (compiled_body)
 	(*v)(compiled_body);
+}
+
+void Closure::applyToCoalescedReferences(std::function<void(const GCNode*)> fun) const
+{
+    // Must also apply to all inherited references:
+    RObject::applyToCoalescedReferences(fun);
+
+    if (m_matcher) {
+	fun(m_matcher);
+    }
 }
 
 void SET_FORMALS(SEXP closure, SEXP formals) {

--- a/src/main/Closure.cpp
+++ b/src/main/Closure.cpp
@@ -70,7 +70,7 @@ Closure::Closure(const PairList* formal_args, RObject* body, Environment* env)
       m_num_invokes(0)
 {
     attachReference(m_matcher, new ArgMatcher(formal_args));
-    m_body = body;
+    attachReference(m_body, body);
     m_environment = env;
 }
 
@@ -88,7 +88,7 @@ Closure* Closure::clone() const
 void Closure::detachReferents()
 {
     detachReference(m_matcher);
-    m_body.detach();
+    detachReference(m_body);
     m_environment.detach();
     m_compiled_body.detach();
     FunctionBase::detachReferents();
@@ -171,7 +171,7 @@ void Closure::setFormals(PairList* formals) {
 }
 
 void Closure::setBody(RObject* body) {
-    m_body = body;
+    retargetReference(m_body, body);
     invalidateCompiledCode();
 }
 
@@ -205,6 +205,9 @@ void Closure::applyToCoalescedReferences(std::function<void(const GCNode*)> fun)
 
     if (m_matcher) {
 	fun(m_matcher);
+    }
+    if (m_body) {
+	fun(m_body);
     }
 }
 


### PR DESCRIPTION
This is an experimental implementation of coalesced reference counting. It is not fit for production yet, but could be polished up if it turns out to be worthwhile.

This implementation steals one bit from the reference count to use as a dirty bit.

Coalescing the reference count for a reference involves the following changes:

* Change the declared field type from `GCEdge<X>` to `X*`
* Change the initial assignment (in the constructor) to `attachReference(x, initialRef)`
* Change any other assignment to `retargetReference(x, newTarget)`
* Replace all calls `x.get()` by a regular access: `x`
* Replace all calls `x.detach()` by `detachReference(x)`
* Override `applyToCoalescedReferences()` in the owner of the reference so that it calls the argument function on the coalesced reference.

The attachReference(), retargetReference() and detachReference() functions are declared in GCNode, they are not static because they need the caller's this pointer to add the caller to the dirty list.

Coalescing a reference means that all outgoing references at the time the node is marked dirty are remembered. If outgoing references were not remembered then the reference counts for objects would be artificially inflated. On the next GC pass all reference counts for outgoing references are decreased, then the current outgoing references of all dirty nodes have their reference counts increased.

To make this work with the current eager reference counting I added a new virtual method in GCNode: `applyToCoalescedReferences(function<void(const GCNode*)>)`. This function is used to remember outgoing references and increase reference counts for current outgoing references (the steps described above).

It would be an error ot not coalesce a reference but then treat it as a current outgoing reference during the GC pass, so I could not reuse GCNode::visitReferents() for coalesced ref. counting. If all references were coalesced, then GCNode::visitReferents() could be repurposed for that.