### PR TITLE
Cleanup use of isnan() and isfinite()

### DIFF
--- a/src/include/R.h
+++ b/src/include/R.h
@@ -40,24 +40,12 @@
 # ifndef __STDC_WANT_IEC_60559_FUNCS_EXT__
 #  define __STDC_WANT_IEC_60559_FUNCS_EXT__ 1
 # endif
-/* The C++ headers in Solaris Studio are strict C++98, and many 
-   packages fail because of not using e.g. std::round 
-   or using C99 functions such as snprintf. 
-*/
-# ifdef __SUNPRO_CC
-#  define DO_NOT_USE_CXX_HEADERS
-# endif
-# if defined(__cplusplus) && !defined(DO_NOT_USE_CXX_HEADERS)
-#  include <cstdlib>
-#  include <cstdio>
-#  include <climits>
-#  include <cmath>
-# else
-#  include <stdlib.h> /* Not used by R itself, but widely assumed in packages */
-#  include <stdio.h>  /* Used by ca 200 packages, but not in R itself */
-#  include <limits.h> /* for INT_MAX */
-#  include <math.h>
-# endif 
+
+#include <stdlib.h> /* Not used by R itself, but widely assumed in packages */
+#include <stdio.h>  /* Used by ca 200 packages, but not in R itself */
+#include <limits.h> /* for INT_MAX */
+#include <math.h>
+
 /* 
    math.h   is also included by R_ext/Arith.h, except in C++ code
    stddef.h is included by R_ext/Memory.h

--- a/src/include/R_ext/Arith.h
+++ b/src/include/R_ext/Arith.h
@@ -37,13 +37,14 @@
 
 #include <R_ext/Boolean.h>
 #include <R_ext/libextern.h>
+#include <math.h>
 
 #ifdef  __cplusplus
-#include <cmath>
-
 extern "C" {
-#elif !defined(NO_C_HEADERS)
-/* needed for isnan and isfinite, neither of which are used under C++ */
+#endif
+
+#ifndef NO_C_HEADERS
+    /* needed for isnan and isfinite */
 # include <math.h>
 #endif
 
@@ -65,60 +66,29 @@ LibExtern int	 R_NaInt;	/* NA_INTEGER:= INT_MIN currently */
 /* NA_STRING is a SEXP, so defined in Rinternals.h */
 
 int R_IsNA(double);		/* True for R's NA only */
-Rboolean R_IsNaN(double);		/* True for special NaN, *not* for NA */
-Rboolean R_finite(double);		/* True if none of NA, NaN, +/-Inf */
+int R_IsNaN(double);		/* True for special NaN, *not* for NA */
+int R_finite(double);		/* True if none of NA, NaN, +/-Inf */
 #define ISNA(x)	       R_IsNA(x)
 
 /* ISNAN(): True for *both* NA and NaN.
    NOTE: some systems do not return 1 for TRUE.
-   Also note that C++ math headers specifically undefine
-   isnan if it is a macro (it is on OS X and in C99),
-   hence the workaround.  This code also appears in Rmath.h
-*/
-#ifdef __cplusplus
-    /* rho Notes:
-     *
-     * isnan() was introduced by C99, which prescribes that it shall
-     * be a macro. ISO14882, even in its 2003 issue, requires only
-     * that <cmath> offer the facilities of math.h as defined in
-     * ISO/IEC 9899:1990.  TR1 proposed that <cmath> make isnan()
-     * available to C++ programs as a templated function within the
-     * std namespace.  On Linux, gcc appears to make the ordinary
-     * isnan() macro available to C++ programs.  However, on Mac OS X
-     * (at least as of 10.5.6) gcc appears to make isnan() available
-     * to C++ programs only as std::isnan().
-     *
-     * The following covers these two cases.  Another possibility that
-     * may need to be addressed is that C++'s isnan() is to be found
-     * in namespace std::tr1.
-     */
-    inline Rboolean R_isnancpp(double x)
-    {
+   C specifies that isnan and isfinite are macros, but the C++ math headers
+   specifically undefine them and are not required to add replacement function
+   declarations in the global namespace.
+
+   This works around that issue.  This code also appears in Rmath.h
+ */
 #ifdef isnan
-	return Rboolean(isnan(x)!=0);
+#  define ISNAN(x) (isnan(x) != 0)
 #else
-	return Rboolean(std::isnan(x)!=0);
+#  define ISNAN(x) std::isnan(x)
 #endif
-    }
+int R_isnancpp(double x);
 
-    /* This anticipates C++ 0x. */
-    inline Rboolean R_finite(double x)
-    {
-	return Rboolean(std::isfinite(x) != 0);
-    }
-
-#  define ISNAN(x)     R_isnancpp(x)
+#ifdef isfinite
+#  define R_FINITE(x) (isfinite(x) != 0)
 #else
-#  define ISNAN(x)     ((Rboolean)(isnan(x)!=0))
-#endif
-
-/* The following is only defined inside R */
-#ifdef HAVE_WORKING_ISFINITE
-/* isfinite is defined in <math.h> according to C99 */
-# define R_FINITE(x)    isfinite(x)
-#else
-
-# define R_FINITE(x)    R_finite(x)
+#  define R_FINITE(x) std::isfinite(x)
 #endif
 
 #ifdef  __cplusplus

--- a/src/include/Rmath.h0.in
+++ b/src/include/Rmath.h0.in
@@ -38,15 +38,7 @@
 # ifndef __STDC_WANT_IEC_60559_FUNCS_EXT__
 #  define __STDC_WANT_IEC_60559_FUNCS_EXT__ 1
 # endif
-/* See the comment in R.h */
-# ifdef __SUNPRO_CC
-#  define DO_NOT_USE_CXX_HEADERS
-# endif
-# if defined(__cplusplus) && !defined(DO_NOT_USE_CXX_HEADERS)
-#  include <cmath>
-# else
-#  include <math.h>
-# endif
+# include <math.h>
 #endif
 
 /*-- Mathlib as part of R --  define this for standalone : */

--- a/src/library/utils/src/io.cpp
+++ b/src/library/utils/src/io.cpp
@@ -973,7 +973,7 @@ static Rboolean isna(SEXP x, int indx)
 	return Rboolean(INTEGER(x)[indx] == NA_INTEGER);
 	break;
     case REALSXP:
-	return ISNAN(REAL(x)[indx]);
+	return Rboolean(ISNAN(REAL(x)[indx]));
 	break;
     case STRSXP:
 	return Rboolean(STRING_ELT(x, indx) == NA_STRING);

--- a/src/main/GCManager.cpp
+++ b/src/main/GCManager.cpp
@@ -31,7 +31,6 @@
 
 #include "rho/GCManager.hpp"
 
-#include <cmath>
 #include <cstdarg>
 #include <iomanip>
 #include <iostream>

--- a/src/main/ListFrame.cpp
+++ b/src/main/ListFrame.cpp
@@ -30,7 +30,6 @@
 
 #include "rho/ListFrame.hpp"
 
-#include <cmath>
 #include "localization.h"
 #include "R_ext/Error.h"
 #include "rho/GCStackRoot.hpp"

--- a/src/main/arithmetic.cpp
+++ b/src/main/arithmetic.cpp
@@ -141,7 +141,7 @@ static double R_ValueOfNA(void)
 
 int R_IsNA(double x)
 {
-    if (isnan(x)) {
+    if (ISNAN(x)) {
 	ieee_double y;
 	y.value = x;
 	return (y.word[lw] == 1954);
@@ -149,9 +149,9 @@ int R_IsNA(double x)
     return 0;
 }
 
-Rboolean R_IsNaN(double x)
+int R_IsNaN(double x)
 {
-    if (isnan(x)) {
+    if (ISNAN(x)) {
 	ieee_double y;
 	y.value = x;
 	return RHOCONSTRUCT(Rboolean, (y.word[lw] != 1954));
@@ -159,17 +159,13 @@ Rboolean R_IsNaN(double x)
     return FALSE;
 }
 
-
 /* Mainly for use in packages */
-
-// Force a non-inline embodiment of R_finite():
-namespace rho {
-    namespace ForceNonInline{
-	Rboolean (*R_finitep)(double) = R_finite;
-        auto R_isnancppPtr = &R_isnancpp;
-    }
+int R_isnancpp(double x) {
+    return ISNAN(x);
 }
-
+int R_finite(double x) {
+    return R_FINITE(x);
+}
 
 /* Arithmetic Initialization */
 
@@ -705,8 +701,8 @@ public:
 	/* This code assumes that isnan(in) implies isnan(m_f(in)), so we
 	   only need to check isnan(in) if isnan(m_f(in)) is true. */
 	double ans = m_f(in);
-	if (isnan(ans)) {
-	    if (isnan(in))
+	if (ISNAN(ans)) {
+	    if (ISNAN(in))
 		ans = in; // ensure the incoming NaN is preserved.
 	    else
 		m_any_NaN = true;


### PR DESCRIPTION
For C++ code that #include's <cmath>, ::isnan and ::isfinite
might not exist.  This change should fix compilation issues on those
platforms.