### PR TITLE
Optimize matching of unnamed argument lists.

### DIFF
--- a/src/include/rho/ArgList.hpp
+++ b/src/include/rho/ArgList.hpp
@@ -372,6 +372,10 @@ namespace rho {
          */
         bool has3Dots() const;
 
+	/** @brief Do any of the arguments have names?
+         */
+	bool hasTags() const;
+
 	/** @brief Remove argument names.
 	 *
 	 * This function removes any tags from the ArgList.  This will

--- a/src/include/rho/ArgMatcher.hpp
+++ b/src/include/rho/ArgMatcher.hpp
@@ -339,6 +339,8 @@ namespace rho {
         void match(const ArgList* supplied, MatchCallback* callback) const;
         void matchWithCache(const ArgList* supplied, MatchCallback* callback,
 			    const ArgMatchInfo* matching) const;
+        void matchByPosition(const ArgList* supplied, MatchCallback* callback)
+	    const;
 
 	// Return true if 'shorter' is a prefix of 'longer', or is
 	// identical to 'longer':
@@ -355,6 +357,7 @@ namespace rho {
 	// Raise an error because there are unused supplied arguments,
 	// as indicated in supplied_list.
 	static void unusedArgsError(const SuppliedList& supplied_list);
+	static void unusedArgsError(const PairList* supplied_list);
 
 	static PairList* makePairList(
 	    std::initializer_list<const char*> arg_names);

--- a/src/main/ArgList.cpp
+++ b/src/main/ArgList.cpp
@@ -198,6 +198,17 @@ bool ArgList::has3Dots() const {
   return false;
 }
 
+bool ArgList::hasTags() const {
+  if (!list())
+    return false;
+
+  for (const ConsCell& cell : *list()) {
+    if (cell.tag())
+      return true;
+  }
+  return false;
+}
+
 void ArgList::stripTags()
 {
     for (PairList* p = mutable_list(); p; p = p->tail())

--- a/src/main/match.cpp
+++ b/src/main/match.cpp
@@ -138,9 +138,16 @@ void ArgMatcher::unusedArgsError(const SuppliedList& supplied_list)
 	    value = const_cast<RObject*>(PREXPR(value));
 	unused_list = PairList::cons(value, unused_list, supplied_data.tag);
     }
+    unusedArgsError(unused_list);
+}
+
+void ArgMatcher::unusedArgsError(const PairList* unused_list)
+{
     // Prepare error message:
     GCStackRoot<StringVector>
-	argstrv(static_cast<StringVector*>(Rf_deparse1line(unused_list, FALSE)));
+	argstrv(static_cast<StringVector*>(
+		    Rf_deparse1line(
+			const_cast<PairList*>(unused_list), FALSE)));
     // '+ 4' is to remove 'list' from 'list(badTag1, ...' :
     const char* errdetails = (*argstrv)[0]->c_str() + 4;
     Rf_error(_("unused argument(s) %s"), errdetails);


### PR DESCRIPTION
The vast majority of function calls in R code don't use named arguments.
In that case, argument matching can be made much simpler and faster.